### PR TITLE
add missing headers for new toolchain

### DIFF
--- a/benchmarks/storage_bench/StorageBench.h
+++ b/benchmarks/storage_bench/StorageBench.h
@@ -2,6 +2,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/core/ignore_unused.hpp>
+#include <boost/filesystem/string_file.hpp>
 #include <common/utils/UtcTime.h>
 #include <folly/experimental/coro/Collect.h>
 #include <folly/futures/Barrier.h>

--- a/src/client/cli/admin/DumpChainTable.cc
+++ b/src/client/cli/admin/DumpChainTable.cc
@@ -1,6 +1,7 @@
 #include "DumpChainTable.h"
 
 #include <folly/Conv.h>
+#include <fstream>
 
 #include "AdminEnv.h"
 #include "client/cli/common/Dispatcher.h"

--- a/src/client/cli/admin/DumpChains.cc
+++ b/src/client/cli/admin/DumpChains.cc
@@ -1,6 +1,7 @@
 #include "DumpChains.h"
 
 #include <folly/Conv.h>
+#include <fstream>
 
 #include "AdminEnv.h"
 #include "client/cli/common/Dispatcher.h"

--- a/src/client/cli/admin/DumpChunkMeta.cc
+++ b/src/client/cli/admin/DumpChunkMeta.cc
@@ -1,6 +1,7 @@
 #include "DumpChunkMeta.h"
 
 #include <folly/logging/xlog.h>
+#include <fstream>
 #include <vector>
 
 #include "AdminEnv.h"

--- a/src/client/cli/admin/DumpInodes.cc
+++ b/src/client/cli/admin/DumpInodes.cc
@@ -8,6 +8,7 @@
 #include <folly/experimental/coro/Invoke.h>
 #include <folly/futures/Future.h>
 #include <folly/logging/xlog.h>
+#include <fstream>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/src/client/cli/admin/RenderConfig.cc
+++ b/src/client/cli/admin/RenderConfig.cc
@@ -1,6 +1,7 @@
 #include "RenderConfig.h"
 
 #include <folly/Conv.h>
+#include <fstream>
 
 #include "AdminEnv.h"
 #include "client/cli/common/Dispatcher.h"

--- a/src/common/utils/VersionInfo.h
+++ b/src/common/utils/VersionInfo.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 
 namespace hf3fs {

--- a/src/fuse/FuseOps.cc
+++ b/src/fuse/FuseOps.cc
@@ -12,6 +12,7 @@
 #include <folly/Utility.h>
 #include <folly/experimental/coro/BlockingWait.h>
 #include <folly/logging/xlog.h>
+#include <fstream>
 #include <fuse3/fuse_lowlevel.h>
 #include <iostream>
 #include <linux/fs.h>

--- a/src/storage/store/StorageTarget.cc
+++ b/src/storage/store/StorageTarget.cc
@@ -2,6 +2,7 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <folly/experimental/symbolizer/Symbolizer.h>
+#include <fstream>
 #include <sys/stat.h>
 
 #include "common/monitor/Recorder.h"

--- a/src/storage/worker/CheckWorker.cc
+++ b/src/storage/worker/CheckWorker.cc
@@ -1,5 +1,7 @@
 #include "storage/worker/CheckWorker.h"
 
+#include <fstream>
+
 #include "common/monitor/Recorder.h"
 #include "common/utils/Duration.h"
 #include "common/utils/UtcTime.h"

--- a/src/storage/worker/DumpWorker.cc
+++ b/src/storage/worker/DumpWorker.cc
@@ -1,6 +1,7 @@
 #include "storage/worker/DumpWorker.h"
 
 #include <gperftools/profiler.h>
+#include <fstream>
 #include <memory>
 #include <sys/times.h>
 

--- a/tests/meta/event/TestEventLogger.cc
+++ b/tests/meta/event/TestEventLogger.cc
@@ -12,6 +12,7 @@
 #include <folly/logging/Logger.h>
 #include <folly/logging/LoggerDB.h>
 #include <folly/logging/xlog.h>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <string_view>
 #include <sys/stat.h>


### PR DESCRIPTION
These are necessary for compiling with Ubuntu 24.04 default toolchain/boost.

Greate job! I've tried to run this on Ubuntu 24.04, facing a lot of issues. I eventually failed because I cannot install the RDMA driver. But I don't want to waste my work. So here is part of my modifications to make it compile.

See also
- #43
- #44
- #45
- #46

With these change, plus some changes to third_party, I'm able to build this on Ubuntu 24.04, with `-Werror` removed and https://github.com/google/leveldb/pull/1255, https://github.com/ClickHouse/clickhouse-cpp/pull/296, https://github.com/facebook/rocksdb/pull/11118