### PR TITLE
add fmt:: namespace to distinguish from std::format_to

### DIFF
--- a/src/client/meta/ServerSelectionStrategy.h
+++ b/src/client/meta/ServerSelectionStrategy.h
@@ -139,7 +139,7 @@ template <>
 struct formatter<hf3fs::meta::client::ServerSelectionStrategy::NodeInfo> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::meta::client::ServerSelectionStrategy::NodeInfo &node, FormatContext &ctx) const {
-    return format_to(ctx.out(), "[{}]@{}.{}", node.address, node.nodeId, node.hostname);
+    return fmt::format_to(ctx.out(), "[{}]@{}.{}", node.address, node.nodeId, node.hostname);
   }
 };
 

--- a/src/client/storage/StorageClient.h
+++ b/src/client/storage/StorageClient.h
@@ -578,15 +578,15 @@ template <>
 struct formatter<hf3fs::storage::client::RoutingTarget> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::storage::client::RoutingTarget &routingTarget, FormatContext &ctx) const {
-    return format_to(ctx.out(),
-                     "{}@{}@{}:{}@{}:{}#{}",
-                     routingTarget.chainId,
-                     routingTarget.chainVer,
-                     routingTarget.routingInfoVer,
-                     routingTarget.targetInfo.targetId,
-                     routingTarget.targetInfo.nodeId,
-                     routingTarget.channel.id,
-                     routingTarget.channel.seqnum);
+    return fmt::format_to(ctx.out(),
+                          "{}@{}@{}:{}@{}:{}#{}",
+                          routingTarget.chainId,
+                          routingTarget.chainVer,
+                          routingTarget.routingInfoVer,
+                          routingTarget.targetInfo.targetId,
+                          routingTarget.targetInfo.nodeId,
+                          routingTarget.channel.id,
+                          routingTarget.channel.seqnum);
   }
 };
 

--- a/src/common/app/AppInfo.h
+++ b/src/common/app/AppInfo.h
@@ -139,7 +139,7 @@ template <>
 struct formatter<hf3fs::flat::ReleaseVersion> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::flat::ReleaseVersion val, FormatContext &ctx) const -> decltype(ctx.out()) {
-    return format_to(ctx.out(), "{}", val.toString());
+    return fmt::format_to(ctx.out(), "{}", val.toString());
   }
 };
 
@@ -148,9 +148,9 @@ struct formatter<hf3fs::flat::TagPair> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::flat::TagPair val, FormatContext &ctx) const -> decltype(ctx.out()) {
     if (val.value.empty()) {
-      return format_to(ctx.out(), "{}", val.key);
+      return fmt::format_to(ctx.out(), "{}", val.key);
     }
-    return format_to(ctx.out(), "{}={}", val.key, val.value);
+    return fmt::format_to(ctx.out(), "{}={}", val.key, val.value);
   }
 };
 

--- a/src/common/app/ClientId.h
+++ b/src/common/app/ClientId.h
@@ -51,7 +51,7 @@ template <>
 struct formatter<hf3fs::ClientId> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::ClientId &clientId, FormatContext &ctx) const {
-    return format_to(ctx.out(), "ClientId({})@{}", clientId.uuid.toHexString(), clientId.hostname);
+    return fmt::format_to(ctx.out(), "ClientId({})@{}", clientId.uuid.toHexString(), clientId.hostname);
   }
 };
 

--- a/src/common/utils/OptionalUtils.h
+++ b/src/common/utils/OptionalUtils.h
@@ -37,9 +37,9 @@ struct formatter<hf3fs::OptionalFmt<T>> : formatter<T> {
   template <typename FormatContext>
   auto format(const hf3fs::OptionalFmt<T> &op, FormatContext &ctx) const {
     if (op.val_.has_value()) {
-      return format_to(ctx.out(), "{}", *op.val_);
+      return fmt::format_to(ctx.out(), "{}", *op.val_);
     } else {
-      return format_to(ctx.out(), "std::nullopt");
+      return fmt::format_to(ctx.out(), "std::nullopt");
     }
   }
 };

--- a/src/common/utils/Result.h
+++ b/src/common/utils/Result.h
@@ -151,7 +151,7 @@ template <typename T>
 struct formatter<hf3fs::Result<T>> : formatter<T> {
   template <typename FormatContext>
   auto format(const hf3fs::Result<T> &result, FormatContext &ctx) const {
-    if (result.hasError()) return format_to(ctx.out(), "{}", result.error());
+    if (result.hasError()) return fmt::format_to(ctx.out(), "{}", result.error());
     return formatter<T>::format(result.value(), ctx);
   }
 };

--- a/src/common/utils/Status.h
+++ b/src/common/utils/Status.h
@@ -167,9 +167,9 @@ struct formatter<hf3fs::Status> : formatter<hf3fs::status_code_t> {
   auto format(const hf3fs::Status &status, FormatContext &ctx) const {
     auto msg = status.message();
     if (msg.empty()) {
-      return format_to(ctx.out(), "{}({})", hf3fs::StatusCode::toString(status.code()), status.code());
+      return fmt::format_to(ctx.out(), "{}({})", hf3fs::StatusCode::toString(status.code()), status.code());
     }
-    return format_to(ctx.out(), "{}({}) {}", hf3fs::StatusCode::toString(status.code()), status.code(), msg);
+    return fmt::format_to(ctx.out(), "{}({}) {}", hf3fs::StatusCode::toString(status.code()), status.code(), msg);
   }
 };
 

--- a/src/common/utils/StrongType.h
+++ b/src/common/utils/StrongType.h
@@ -109,9 +109,9 @@ template <hf3fs::StrongTyped T>
 struct formatter<T> : formatter<typename T::UnderlyingType> {
   template <typename FormatContext>
   auto format(const T &strongTyped, FormatContext &ctx) const {
-    format_to(ctx.out(), "{}(", T::kTypeName);
+    fmt::format_to(ctx.out(), "{}(", T::kTypeName);
     formatter<typename T::UnderlyingType>::format(strongTyped.toUnderType(), ctx);
-    return format_to(ctx.out(), ")");
+    return fmt::format_to(ctx.out(), ")");
   }
 };
 
@@ -120,11 +120,11 @@ struct formatter<std::optional<T>> : formatter<typename T::UnderlyingType> {
   template <typename FormatContext>
   auto format(const std::optional<T> &strongTyped, FormatContext &ctx) const {
     if (strongTyped.has_value()) {
-      format_to(ctx.out(), "{}(", T::kTypeName);
+      fmt::format_to(ctx.out(), "{}(", T::kTypeName);
       formatter<typename T::UnderlyingType>::format(strongTyped->toUnderType(), ctx);
-      return format_to(ctx.out(), ")");
+      return fmt::format_to(ctx.out(), ")");
     } else {
-      return format_to(ctx.out(), "{}(std::nullopt)", T::kTypeName);
+      return fmt::format_to(ctx.out(), "{}(std::nullopt)", T::kTypeName);
     }
   }
 };

--- a/src/fbs/core/user/User.h
+++ b/src/fbs/core/user/User.h
@@ -80,11 +80,11 @@ struct formatter<hf3fs::flat::UserInfo> : formatter<std::string_view> {
   auto format(const hf3fs::flat::UserInfo &user, FormatContext &ctx) const {
     auto groups = transformTo<std::vector>(std::span{user.groups.begin(), user.groups.size()},
                                            [](hf3fs::flat::Gid gid) { return gid.toUnderType(); });
-    return format_to(ctx.out(),
-                     "(uid {}, gid {}, groups ({}))",
-                     user.uid.toUnderType(),
-                     user.gid.toUnderType(),
-                     fmt::join(groups.begin(), groups.end(), ","));
+    return fmt::format_to(ctx.out(),
+                          "(uid {}, gid {}, groups ({}))",
+                          user.uid.toUnderType(),
+                          user.gid.toUnderType(),
+                          fmt::join(groups.begin(), groups.end(), ","));
   }
 };
 

--- a/src/fbs/meta/Schema.h
+++ b/src/fbs/meta/Schema.h
@@ -436,7 +436,7 @@ template <>
 struct formatter<hf3fs::meta::InodeType> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(hf3fs::meta::InodeType type, FormatContext &ctx) const {
-    return format_to(ctx.out(), "{}", magic_enum::enum_name(type));
+    return fmt::format_to(ctx.out(), "{}", magic_enum::enum_name(type));
   }
 };
 
@@ -444,7 +444,7 @@ template <>
 struct formatter<hf3fs::meta::ChunkId> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(hf3fs::meta::ChunkId chunk, FormatContext &ctx) const {
-    return format_to(ctx.out(), "{}-{}-{}", chunk.inode(), chunk.track(), chunk.chunk());
+    return fmt::format_to(ctx.out(), "{}-{}-{}", chunk.inode(), chunk.track(), chunk.chunk());
   }
 };
 
@@ -452,7 +452,7 @@ template <>
 struct formatter<hf3fs::meta::Layout::ChunkSize> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(hf3fs::meta::Layout::ChunkSize chunk, FormatContext &ctx) const {
-    return format_to(ctx.out(), "{}", (uint64_t)chunk);
+    return fmt::format_to(ctx.out(), "{}", (uint64_t)chunk);
   }
 };
 
@@ -460,7 +460,7 @@ template <>
 struct formatter<hf3fs::meta::VersionedLength> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(hf3fs::meta::VersionedLength v, FormatContext &ctx) const {
-    return format_to(ctx.out(), "{}@{}", v.length, v.truncateVer);
+    return fmt::format_to(ctx.out(), "{}@{}", v.length, v.truncateVer);
   }
 };
 

--- a/src/fbs/mgmtd/ChainRef.h
+++ b/src/fbs/mgmtd/ChainRef.h
@@ -42,7 +42,7 @@ struct formatter<hf3fs::flat::ChainRef> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::flat::ChainRef &ref, FormatContext &ctx) const {
     auto [id, v, i] = ref.decode();
-    return format_to(ctx.out(), "ChainRef({}@{}-{})", id.toUnderType(), v.toUnderType(), i);
+    return fmt::format_to(ctx.out(), "ChainRef({}@{}-{})", id.toUnderType(), v.toUnderType(), i);
   }
 };
 

--- a/src/fbs/storage/Common.h
+++ b/src/fbs/storage/Common.h
@@ -744,7 +744,7 @@ template <>
 struct formatter<hf3fs::storage::ChunkId> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::storage::ChunkId &chunkId, FormatContext &ctx) const {
-    return format_to(ctx.out(), "ChunkId({})", chunkId.describe());
+    return fmt::format_to(ctx.out(), "ChunkId({})", chunkId.describe());
   }
 };
 
@@ -753,13 +753,13 @@ struct formatter<hf3fs::storage::ChunkIdRange> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::storage::ChunkIdRange &range, FormatContext &ctx) const {
     if (range.maxNumChunkIdsToProcess == 1) {
-      return format_to(ctx.out(), "{}", range.begin);
+      return fmt::format_to(ctx.out(), "{}", range.begin);
     } else {
-      return format_to(ctx.out(),
-                       "ChunkIdRange[{}, {}){{{}}}",
-                       range.begin.describe(),
-                       range.end.describe(),
-                       range.maxNumChunkIdsToProcess);
+      return fmt::format_to(ctx.out(),
+                            "ChunkIdRange[{}, {}){{{}}}",
+                            range.begin.describe(),
+                            range.end.describe(),
+                            range.maxNumChunkIdsToProcess);
     }
   }
 };
@@ -768,7 +768,7 @@ template <>
 struct formatter<hf3fs::storage::ChecksumInfo> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::storage::ChecksumInfo &checksum, FormatContext &ctx) const {
-    return format_to(ctx.out(), "{}#{:08X}", magic_enum::enum_name(checksum.type), ~checksum.value);
+    return fmt::format_to(ctx.out(), "{}#{:08X}", magic_enum::enum_name(checksum.type), ~checksum.value);
   }
 };
 
@@ -776,13 +776,13 @@ template <>
 struct formatter<hf3fs::storage::IOResult> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::storage::IOResult &result, FormatContext &ctx) const {
-    return format_to(ctx.out(),
-                     "length{{{}}} version{{{}/{}}} checksum{{{}}} {{{}}}",
-                     result.lengthInfo,
-                     result.updateVer,
-                     result.commitVer,
-                     result.checksum,
-                     result.commitChainVer);
+    return fmt::format_to(ctx.out(),
+                          "length{{{}}} version{{{}/{}}} checksum{{{}}} {{{}}}",
+                          result.lengthInfo,
+                          result.updateVer,
+                          result.commitVer,
+                          result.checksum,
+                          result.commitChainVer);
   }
 };
 
@@ -790,7 +790,7 @@ template <>
 struct formatter<hf3fs::storage::UpdateChannel> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::storage::UpdateChannel &channel, FormatContext &ctx) const {
-    return format_to(ctx.out(), "@{}#{}", channel.id, channel.seqnum);
+    return fmt::format_to(ctx.out(), "@{}#{}", channel.id, channel.seqnum);
   }
 };
 
@@ -798,7 +798,7 @@ template <>
 struct formatter<hf3fs::storage::MessageTag> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::storage::MessageTag &tag, FormatContext &ctx) const {
-    return format_to(ctx.out(), "@{}#{}:{}", tag.clientId, tag.requestId, tag.channel);
+    return fmt::format_to(ctx.out(), "@{}#{}:{}", tag.clientId, tag.requestId, tag.channel);
   }
 };
 

--- a/src/meta/components/SessionManager.h
+++ b/src/meta/components/SessionManager.h
@@ -134,11 +134,11 @@ template <>
 struct formatter<hf3fs::meta::server::FileSession> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const hf3fs::meta::server::FileSession &session, FormatContext &ctx) const {
-    return format_to(ctx.out(),
-                     "{{inodeId {}, client {}, session {}}}",
-                     session.inodeId,
-                     session.clientId,
-                     session.sessionId);
+    return fmt::format_to(ctx.out(),
+                          "{{inodeId {}, client {}, session {}}}",
+                          session.inodeId,
+                          session.clientId,
+                          session.sessionId);
   }
 };
 


### PR DESCRIPTION
When compiled with new toolchain that implements std::format_to, it become ambiguous on which one should be called. Due to argument-dependent lookup, even if we are not `using namespace std;` the std version is still considered. So let's add fmt:: to avoid ambiguous compilation error.