### PR TITLE
robin hood: resolve warning on new clang

### DIFF
--- a/src/common/utils/RobinHood.h
+++ b/src/common/utils/RobinHood.h
@@ -203,14 +203,6 @@ static Counts &counts() {
 #define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
 #endif
 
-// workaround missing "is_trivially_copyable" in g++ < 5.0
-// See https://stackoverflow.com/a/31798726/48181
-#if defined(__GNUC__) && __GNUC__ < 5
-#define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
-#else
-#define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
-#endif
-
 // helpers for C++ versions, see https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
 #define ROBIN_HOOD_PRIVATE_DEFINITION_CXX() __cplusplus
 #define ROBIN_HOOD_PRIVATE_DEFINITION_CXX98() 199711L
@@ -1382,7 +1374,7 @@ class Table
                : static_cast<size_t>(std::distance(mKeyVals, reinterpret_cast_no_cast_align_warning<Node *>(mInfo)));
   }
 
-  void cloneData(const Table &o) { Cloner<Table, IsFlat && ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(Node)>()(o, *this); }
+  void cloneData(const Table &o) { Cloner<Table, IsFlat && std::is_trivially_copyable<Node>::value>()(o, *this); }
 
   // inserts a keyval that is guaranteed to be new, e.g. when the hashmap is resized.
   // @return True on success, false if something went wrong


### PR DESCRIPTION
Clang has this weird behavior of setting `__GNUC__` to 4, hence clang will always take the if branch. This is suboptimal because std::is_trivially_copyable has almost always been in clang.

starting with clang 15 a warning is raised for the current implementation: warning: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Wdeprecated-builtins]

Since we are using -Werror, we should fix this.

Note this resolves the same issue with https://github.com/martinus/robin-hood-hashing/pull/166 , but with a different patch. 
But that PR is never released, and the original repo is archived. So, I just removed this helper. GCC4 is too old to support.