### PR TITLE
Remove unused dependency libprocps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Prepare
       run: |
-        sudo apt install -y cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libprocps-dev libdwarf-dev libunwind-dev
+        sudo apt install -y cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libdwarf-dev libunwind-dev
         sudo apt install -y libaio-dev libgflags-dev libgoogle-glog-dev libgtest-dev libgmock-dev clang-format-14 clang-14 clang-tidy-14 lld-14
         sudo apt install -y libgoogle-perftools-dev google-perftools libssl-dev gcc-12 g++-12 libboost-all-dev meson rustc cargo
         wget https://github.com/apple/foundationdb/releases/download/7.1.61/foundationdb-clients_7.1.61-1_amd64.deb && sudo dpkg -i foundationdb-clients_7.1.61-1_amd64.deb

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ Install dependencies:
 
 ```bash
 # for Ubuntu 20.04.
-apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libprocps-dev libdwarf-dev libunwind-dev \
+apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libdwarf-dev libunwind-dev \
   libaio-dev libgflags-dev libgoogle-glog-dev libgtest-dev libgmock-dev clang-format-14 clang-14 clang-tidy-14 lld-14 \
   libgoogle-perftools-dev google-perftools libssl-dev libclang-rt-14-dev gcc-10 g++-10 libboost1.71-all-dev
 
 # for Ubuntu 22.04.
-apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libprocps-dev libdwarf-dev libunwind-dev \
+apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libdwarf-dev libunwind-dev \
   libaio-dev libgflags-dev libgoogle-glog-dev libgtest-dev libgmock-dev clang-format-14 clang-14 clang-tidy-14 lld-14 \
   libgoogle-perftools-dev google-perftools libssl-dev gcc-12 g++-12 libboost-all-dev
 ```

--- a/src/lib/api/CMakeLists.txt
+++ b/src/lib/api/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_add_lib(hf3fs_api client-lib-common storage-client procps numa rt)
-target_add_shared_lib(hf3fs_api_shared client-lib-common storage-client procps numa rt)
+target_add_lib(hf3fs_api client-lib-common storage-client numa rt)
+target_add_shared_lib(hf3fs_api_shared client-lib-common storage-client numa rt)


### PR DESCRIPTION
This package is not included in Ubuntu 24.04. And we are not actually using it. So just don't link it.