### PR TITLE
explicit down cast

### DIFF
--- a/benchmarks/storage_bench/StorageBench.cc
+++ b/benchmarks/storage_bench/StorageBench.cc
@@ -124,7 +124,7 @@ bool runBenchmarks() {
     auto nodeIdStr = nodeEndpointStrs[0];
     auto endpointStr = nodeEndpointStrs[1];
 
-    NodeId nodeId{std::stoul(nodeIdStr)};
+    auto nodeId = (NodeId)std::stoul(nodeIdStr);
     auto endpoint = net::Address::fromString(endpointStr);
     storageEndpoints[nodeId] = endpoint;
     XLOGF(WARN, "Add storage endpoint: {} @ {}", nodeId, endpoint);

--- a/src/client/storage/UpdateChannelAllocator.cc
+++ b/src/client/storage/UpdateChannelAllocator.cc
@@ -12,8 +12,8 @@ static monitor::CountRecorder num_update_channels_total{"storage_client.num_upda
 UpdateChannelAllocator::UpdateChannelAllocator(size_t numChannels)
     : numChannels_(std::min(kMaxNumChannels, numChannels)) {
   std::scoped_lock lock(availableChannelMutex_);
-  for (uint32_t id = numChannels_; id > 0; id--) {
-    availableChannelIds_.push(ChannelId{id});
+  for (auto id = (ChannelId)numChannels_; id > 0; id--) {
+    availableChannelIds_.push(id);
     num_update_channels_total.addSample(1);
   }
 }

--- a/src/fuse/UserConfig.cc
+++ b/src/fuse/UserConfig.cc
@@ -141,7 +141,7 @@ Result<meta::Inode> UserConfig::statConfig(meta::InodeId iid, const meta::UserIn
   auto key = isSys ? systemKeys[kidx] : userKeys[kidx];
   return meta::Inode{iid,
                      {meta::Symlink{config.find(key).value()->toString()},
-                      meta::Acl{ui.uid, ui.gid, meta::Permission{isSys ? 0444 : 0400}}}};
+                      meta::Acl{ui.uid, ui.gid, meta::Permission{isSys ? 0444u : 0400u}}}};
 }
 
 std::pair<std::shared_ptr<std::vector<meta::DirEntry>>, std::shared_ptr<std::vector<std::optional<meta::Inode>>>>

--- a/tests/analytics/TestStructuredTraceLog.cc
+++ b/tests/analytics/TestStructuredTraceLog.cc
@@ -50,7 +50,7 @@ auto createStorageEventTrace(size_t id) {
                       ClientId::zero(),
                       storage::RequestId{id},
                       storage::UpdateChannel{
-                          .id = storage::ChannelId{id},
+                          .id = (storage::ChannelId)id,
                           .seqnum = storage::ChannelSeqNum{id},
                       },
                   },

--- a/tests/lib/UnitTestFabric.cc
+++ b/tests/lib/UnitTestFabric.cc
@@ -375,7 +375,7 @@ bool UnitTestFabric::setUpStorageSystem() {
 
   if (!setupConfig_.start_storage_server()) {
     for (auto &[key, value] : storageEndpoints) {
-      nodeEndpoints[storage::NodeId{std::stoul(key)}] = value;
+      nodeEndpoints[(storage::NodeId)std::stoul(key)] = value;
     }
   } else {
     for (uint32_t nodeIndex = 0; nodeIndex < numStorageNodes; nodeIndex++) {


### PR DESCRIPTION
Newer clang does not allow down cast with brace initialization. Replace them with C-style cast.