### PR TITLE
Minor optimize copying of shared_ptr in IBSocket and StorageTargets

### DIFF
--- a/src/common/net/ib/IBSocket.cc
+++ b/src/common/net/ib/IBSocket.cc
@@ -1107,7 +1107,7 @@ IBSocket::Drainer::Ptr IBSocket::Drainer::create(IBSocket::Ptr socket, std::weak
 
 IBSocket::Drainer::Drainer(IBSocket::Ptr socket, std::weak_ptr<IBSocketManager> manager)
     : socket_(std::move(socket)),
-      manager_(manager) {
+      manager_(std::move(manager)) {
   draining.addSample(1);
 }
 

--- a/src/common/net/ib/IBSocket.h
+++ b/src/common/net/ib/IBSocket.h
@@ -570,7 +570,7 @@ class IBSocketManager : public EventLoop::EventHandler, public std::enable_share
 
  private:
   friend class IBSocket::Drainer;
-  void remove(IBSocket::Drainer::Ptr drainer) { drainers_.lock()->erase(drainer); }
+  void remove(const IBSocket::Drainer::Ptr &drainer) { drainers_.lock()->erase(drainer); }
 
   FdWrapper timer_;
   folly::Synchronized<std::set<IBSocket::Drainer::Ptr>, std::mutex> drainers_;

--- a/src/storage/store/StorageTargets.cc
+++ b/src/storage/store/StorageTargets.cc
@@ -115,7 +115,7 @@ Result<Void> StorageTargets::create(const CreateConfig &createConfig) {
     targetConfig.only_chunk_engine = createConfig.only_chunk_engine();
     RETURN_AND_LOG_ON_ERROR(storageTarget->create(targetConfig));
     ++idx;
-    RETURN_AND_LOG_ON_ERROR(targetMap_.addStorageTarget(storageTarget));
+    RETURN_AND_LOG_ON_ERROR(targetMap_.addStorageTarget(std::move(storageTarget)));
   }
   return Void{};
 }
@@ -189,7 +189,7 @@ Result<Void> StorageTargets::create(const CreateTargetReq &req) {
   targetConfig.only_chunk_engine = req.onlyChunkEngine;
   RETURN_AND_LOG_ON_ERROR(storageTarget->create(targetConfig));
   XLOGF(INFO, "Create storage target {} at {}", storageTarget->targetId(), targetPath.string());
-  RETURN_AND_LOG_ON_ERROR(targetMap_.addStorageTarget(storageTarget));
+  RETURN_AND_LOG_ON_ERROR(targetMap_.addStorageTarget(std::move(storageTarget)));
   return Void{};
 }
 
@@ -242,7 +242,7 @@ Result<Void> StorageTargets::loadTarget(const Path &targetPath) {
     XLOG(ERR, msg);
     return makeError(StorageCode::kStorageInitFailed, std::move(msg));
   }
-  RETURN_AND_LOG_ON_ERROR(targetMap_.addStorageTarget(storageTarget));
+  RETURN_AND_LOG_ON_ERROR(targetMap_.addStorageTarget(std::move(storageTarget)));
   return Void{};
 }
 


### PR DESCRIPTION
I notice  IBSocket and StorageTargets would copying the pointer during constructor or erasing, which might introduce unneccssary costs.

Feel free to close this since it's just low-quality contribution :-)