### PR TITLE
Document minimum supported rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 authors = ["dev <noreply@deepseek.com>"]
 edition = "2021"
 license = "MIT"
+rust-version = "1.75.0" # MSRV
 
 [profile.release-cmake]
 debug = true

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Install other build prerequisites:
 
 - [`libfuse`](https://github.com/libfuse/libfuse/releases/tag/fuse-3.16.1) 3.16.1 or newer version
 - [FoundationDB](https://apple.github.io/foundationdb/getting-started-linux.html) 7.1 or newer version
-- [Rust](https://www.rust-lang.org/tools/install) toolchain
+- [Rust](https://www.rust-lang.org/tools/install) toolchain: minimal 1.75.0, recommanded 1.85.0 or newer version (latest stable version) 
 
 ## Build 3FS
 

--- a/src/client/trash_cleaner/Cargo.toml
+++ b/src/client/trash_cleaner/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/client/trash_cleaner/src/main.rs
+++ b/src/client/trash_cleaner/src/main.rs
@@ -598,7 +598,11 @@ struct Opt {
     paths: Vec<PathBuf>,
 
     /// Interval in seconds
-    #[structopt(short, long, help = "Scan interval (in seconds), exit after one scan if set to 0")]
+    #[structopt(
+        short,
+        long,
+        help = "Scan interval (in seconds), exit after one scan if set to 0"
+    )]
     interval: u64,
 
     #[structopt(long)]
@@ -615,7 +619,11 @@ struct Opt {
     #[structopt(long, default_value = "info", help = "Log level, default is info")]
     log_level: Level,
 
-    #[structopt(long, default_value = "warn", help = "stdout log level, default is warn")]
+    #[structopt(
+        long,
+        default_value = "warn",
+        help = "stdout log level, default is warn"
+    )]
     stdout_level: Level,
 }
 

--- a/src/storage/chunk_engine/Cargo.toml
+++ b/src/storage/chunk_engine/Cargo.toml
@@ -2,6 +2,8 @@
 name = "chunk_engine"
 version = "0.1.11"
 edition = "2021"
+license.workspace = true
+rust-version.workspace = true
 
 [lib]
 crate-type = ["lib", "staticlib"]


### PR DESCRIPTION
This PR
+ finds that the MSRV is 1.75.0
+ documents MSRV and recommanded Rust version in README
+ runs `cargo fmt`
