### PR TITLE
Refactor: Replace magic number with constexpr for better readability

### DIFF
--- a/src/fbs/meta/Common.h
+++ b/src/fbs/meta/Common.h
@@ -59,6 +59,8 @@ enum AccessType {
   READ = 4,
 };
 
+static constexpr auto kRemoveChunkBatchSize = 32u;
+
 BOOST_BITMASK(AccessType)
 
 template <typename C, typename T>

--- a/src/fbs/meta/Service.h
+++ b/src/fbs/meta/Service.h
@@ -351,7 +351,7 @@ struct OpenReq : ReqBase {
         path(std::move(path)),
         session(session),
         flags(flags),
-        removeChunksBatchSize(32),
+        removeChunksBatchSize(kRemoveChunkBatchSize),
         dynStripe(dynStripe) {}
   Result<Void> valid() const {
     RETURN_ON_ERROR(flags.valid());


### PR DESCRIPTION
Replaced the hardcoded value `32` with `DefaultRemoveChunksBatchSize` to improve readability and maintainability.