### PR TITLE
fuse: don't limit max_threads to num of CPU cores

### DIFF
--- a/src/fuse/FuseClients.cc
+++ b/src/fuse/FuseClients.cc
@@ -77,12 +77,7 @@ Result<Void> FuseClients::init(const flat::AppInfo &appInfo,
   enableWritebackCache = fuseConfig.enable_writeback_cache();
   memsetBeforeRead = fuseConfig.memset_before_read();
   maxIdleThreads = fuseConfig.max_idle_threads();
-  int logicalCores = std::thread::hardware_concurrency();
-  if (logicalCores != 0) {
-    maxThreads = std::min(fuseConfig.max_threads(), (logicalCores + 1) / 2);
-  } else {
-    maxThreads = fuseConfig.max_threads();
-  }
+  maxThreads = fuseConfig.max_threads();
   bufPool = net::RDMABufPool::create(fuseConfig.io_bufs().max_buf_size(), fuseConfig.rdma_buf_pool_size());
 
   iovs.init(fuseRemountPref.value_or(fuseMountpoint), fuseConfig.iov_limit());


### PR DESCRIPTION
fuse threads are mostly blocked on waiting IO. They are not CPU intensive. So, there is no reason to limit them by the number of CPU cores.

We got 7x IOPS with this patch on a 2 core VM.

On AlibabaCloud ecs.g8a.large. From 3k IOPS to 21k.