### PR TITLE
Fix typo

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,7 @@ Checks: >
   bugprone-integer-division,
   bugprone-macro-repeated-side-effects,
   bugprone-misplaced-operator-in-strlen-in-alloc,
-  bugprone-misplaced-pointer-artithmetic-in-alloc,
+  bugprone-misplaced-pointer-arithmetic-in-alloc,
   bugprone-misplaced-widening-cast,
   bugprone-move-forwarding-reference,
   bugprone-multiple-statement-macro,

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Install other build prerequisites:
 
 - [`libfuse`](https://github.com/libfuse/libfuse/releases/tag/fuse-3.16.1) 3.16.1 or newer version
 - [FoundationDB](https://apple.github.io/foundationdb/getting-started-linux.html) 7.1 or newer version
-- [Rust](https://www.rust-lang.org/tools/install) toolchain: minimal 1.75.0, recommanded 1.85.0 or newer version (latest stable version) 
+- [Rust](https://www.rust-lang.org/tools/install) toolchain: minimal 1.75.0, recommended 1.85.0 or newer version (latest stable version) 
 
 ## Build 3FS
 


### PR DESCRIPTION
Hi, 3FS maintainers

This MR fix typos in `README.md` and `.clang-tidy`.

Related reference: https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone-misplaced-pointer-arithmetic-in-alloc.html