### PR TITLE
feat(build): add arm64 support for openEuler OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,17 @@ endif()
 # Remove project root from the __FILE__ macro variable
 add_compile_options(-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=.)
 
-add_compile_options(-msse4.2 -mavx2)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    add_compile_options(-msse4.2 -mavx2)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    # ARM architecture detected:
+    # Clang on ARM uses built-in runtime library (compiler-rt) to provide symbols like '__muloti4'.
+    # Without explicitly specifying '-rtlib=compiler-rt', linking may fail due to missing '__muloti4'.
+    # '-unwindlib=libgcc' ensures proper exception unwinding compatibility.
+    add_compile_options(-march=armv8-a)
+    message(STATUS "ARM architecture detected, linking with compiler-rt and libgcc.")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rtlib=compiler-rt -unwindlib=libgcc")
+endif()
 add_compile_definitions(ROCKSDB_NAMESPACE=rocksdb_internal)
 include(cmake/Sanitizers.cmake)
 include(cmake/CompileFlags.cmake)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev lib
 apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libdwarf-dev libunwind-dev \
   libaio-dev libgflags-dev libgoogle-glog-dev libgtest-dev libgmock-dev clang-format-14 clang-14 clang-tidy-14 lld-14 \
   libgoogle-perftools-dev google-perftools libssl-dev gcc-12 g++-12 libboost-all-dev
+
+# for openEuler 2403sp1
+yum install cmake libuv-devel lz4-devel xz-devel double-conversion-devel libdwarf-devel libunwind-devel \
+    libaio-devel gflags-devel glog-devel gtest-devel gmock-devel clang-tools-extra clang lld \
+    gperftools-devel gperftools openssl-devel gcc gcc-c++ boost-devel
 ```
 
 Install other build prerequisites:


### PR DESCRIPTION
- Enable compilation on arm64 (aarch64) architecture by conditionally adjusting compiler flags.
- Ensure proper linkage with compiler-rt and libgcc on ARM to resolve missing symbol issues.
- Update README.md with installation instructions for openEuler 2403sp1.