### PR TITLE
Abstract KV layer options to eliminate dynamic casts to FDBTransaction

### DIFF
--- a/src/common/kv/ITransaction.h
+++ b/src/common/kv/ITransaction.h
@@ -31,6 +31,13 @@ static constexpr std::string_view kMetadataVersionKey = "\xff/metadataVersion";
 using Versionstamp = std::array<uint8_t, 10>;
 static_assert(sizeof(Versionstamp) == 10);
 
+enum class Priority : uint8_t {
+  MIN = 0,
+  LOW = 1,
+  HIGH = 2,
+  MAX = 3,
+};
+
 class IReadOnlyTransaction {
  public:
   virtual ~IReadOnlyTransaction() = default;
@@ -83,6 +90,8 @@ class IReadOnlyTransaction {
 
   virtual CoTryTask<void> cancel() = 0;
   virtual void reset() = 0;
+
+  virtual Result<Void> enableStaleRead() = 0;
 };
 
 class IReadWriteTransaction : public IReadOnlyTransaction {
@@ -109,6 +118,8 @@ class IReadWriteTransaction : public IReadOnlyTransaction {
 
   virtual CoTryTask<void> commit() = 0;
   virtual int64_t getCommittedVersion() = 0;
+
+  virtual Result<Void> setPriority(Priority priority) = 0;
 };
 
 struct TransactionHelper {

--- a/src/common/kv/mem/MemTransaction.h
+++ b/src/common/kv/mem/MemTransaction.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <boost/core/ignore_unused.hpp>
 #include <cassert>
 #include <folly/Likely.h>
 #include <folly/Synchronized.h>
@@ -243,6 +244,12 @@ class MemTransaction : public IReadWriteTransaction {
     changes_.clear();
     versionstampedChanges_.clear();
     writeConflicts_.clear();
+  }
+
+  Result<Void> enableStaleRead() override { return Void{}; }
+  Result<Void> setPriority(Priority priority) override {
+    boost::ignore_unused(priority);
+    return Void{};
   }
 
   // check txn1 updated txn2's read set

--- a/src/fdb/FDBTransaction.cc
+++ b/src/fdb/FDBTransaction.cc
@@ -392,6 +392,22 @@ void FDBTransaction::reset() {
   tr_.reset();
 }
 
+Result<Void> FDBTransaction::enableStaleRead() {
+  return setOption(FDBTransactionOption::FDB_TR_OPTION_USE_GRV_CACHE, {});
+}
+
+Result<Void> FDBTransaction::setPriority(Priority priority) {
+  assert(priority > PRIORITY::MIN && priority < PRIORITY::MAX);
+  switch (priority) {
+    case Priority::LOW: {
+      return setOption(FDBTransactionOption::FDB_TR_OPTION_PRIORITY_BATCH, {});
+    } break;
+    default: {
+      return Void{};
+    } break;
+  }
+}
+
 Result<Void> FDBTransaction::setOption(FDBTransactionOption option, std::string_view value) {
   fdb_error_t errcode = tr_.setOption(option, value);
   if (errcode != 0) {

--- a/src/fdb/FDBTransaction.h
+++ b/src/fdb/FDBTransaction.h
@@ -40,6 +40,8 @@ class FDBTransaction : public IReadWriteTransaction {
   CoTryTask<void> commit() override;
   void reset() override;
 
+  Result<Void> enableStaleRead() override;
+  Result<Void> setPriority(Priority priority) override;
   Result<Void> setOption(FDBTransactionOption option, std::string_view value = {});
   CoTask<bool> onError(fdb_error_t errcode);
 

--- a/src/meta/store/Operation.h
+++ b/src/meta/store/Operation.h
@@ -168,9 +168,8 @@ class OperationDriver {
     }
 
     auto grvCache = operation_.isReadOnly() && enableGrvCache;
-    if (grvCache && dynamic_cast<kv::FDBTransaction *>(txn.get())) {
-      auto fdbTxn = dynamic_cast<kv::FDBTransaction *>(txn.get());
-      CO_RETURN_ON_ERROR(fdbTxn->setOption(FDBTransactionOption::FDB_TR_OPTION_USE_GRV_CACHE, {}));
+    if (grvCache) {
+      CO_RETURN_ON_ERROR(txn->enableStaleRead());
     }
 
     Result<Rsp> result = makeError(MetaCode::kOperationTimeout);

--- a/tests/common/TestWithTransaction.cc
+++ b/tests/common/TestWithTransaction.cc
@@ -1,3 +1,4 @@
+#include <boost/core/ignore_unused.hpp>
 #include <folly/experimental/coro/BlockingWait.h>
 #include <gtest/gtest.h>
 #include <string_view>
@@ -65,6 +66,8 @@ class MockROTxn : public IReadOnlyTransaction {
   void reset() override {}
 
   void setReadVersion(int64_t) override {}
+
+  Result<Void> enableStaleRead() override { return Void{}; }
 };
 
 class MockRWTxn : public IReadWriteTransaction {
@@ -112,6 +115,12 @@ class MockRWTxn : public IReadWriteTransaction {
   void setReadVersion(int64_t) override {}
 
   void reset() override {}
+
+  Result<Void> enableStaleRead() override { return Void{}; }
+  Result<Void> setPriority(Priority priority) override {
+    boost::ignore_unused(priority);
+    return Void{};
+  }
 
  private:
   OpResultSeq &commitSeq_;


### PR DESCRIPTION
The use of `dynamic_cast` can bypass the common functionality defined by the interface classes (`IReadOnlyTransaction` and `IReadWriteTransaction`) and instead rely on specific implementation details. This might not be ideal, as it reduces abstraction and increases coupling to a particular implementation. To address this, I attempted to define common option-setting functions.

I considered two approaches:

1. Providing a universal function such as `setOption(TransactionOption option, std::string_view value)` that can handle all options.
2. Using separate, specific functions like `enableStaleRead` and `setPriority`.

I chose the second approach because it assumes there are not many options to set, and this method is clearer and type-safe compared to passing raw value strings.

Thank you for taking the time to review. Feel free to close the MR if it is too small or not helpful.
