### PR TITLE
Deprecate usage of some functions in boost

### DIFF
--- a/benchmarks/storage_bench/StorageBench.h
+++ b/benchmarks/storage_bench/StorageBench.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <random>
 #include <vector>
+#include <fstream>
 
 #include "common/logging/LogInit.h"
 #include "common/net/ib/IBDevice.h"
@@ -398,12 +399,21 @@ class StorageBench : public test::UnitTestFabric {
 
     if (!boost::filesystem::exists(outFilePath) || boost::filesystem::is_empty(outFilePath)) {
       XLOGF(INFO, "Create a file for perfermance stats at {}", outFilePath);
-      boost::filesystem::save_string_file(
-          outFilePath,
-          "test name,#storages,#chains,#replicas,concurrency,batch size,"
-          "io size (bytes),effective batch size (batch size / #replicas),elapsed time (us),"
-          "QPS,IOPS,bandwidth (MB/s),latency samples,min latency (us),max latency (us),avg latency (us),"
-          "latency P50 (us),latency P75 (us),latency P90 (us),latency P95 (us),latency P99 (us)\n");
+      std::ofstream outFile(outFilePath);
+      if (!outFile) {
+          throw std::runtime_error("Failed to open file: " + outFilePath.string());
+      }
+
+      outFile << "test name,#storages,#chains,#replicas,concurrency,batch size,"
+                 "io size (bytes),effective batch size (batch size / #replicas),elapsed time (us),"
+                 "QPS,IOPS,bandwidth (MB/s),latency samples,min latency (us),max latency (us),avg latency (us),"
+                 "latency P50 (us),latency P75 (us),latency P90 (us),latency P95 (us),latency P99 (us)\n";
+
+      if (!outFile) {
+          throw std::runtime_error("Failed to write to file: " + outFilePath.string());
+      }
+
+      outFile.close();
     }
 
     auto elapsedMicro = std::chrono::duration_cast<std::chrono::microseconds>(elapsedTime);

--- a/src/common/utils/FileUtils.cc
+++ b/src/common/utils/FileUtils.cc
@@ -1,12 +1,15 @@
 #include "FileUtils.h"
 
-#include <boost/filesystem/string_file.hpp>
+#include <fstream>
 
 namespace hf3fs {
 Result<std::string> loadFile(const Path &path) {
   try {
-    std::string output;
-    boost::filesystem::load_string_file(path, output);
+    std::ifstream file(path);
+    if (!file) {
+      return makeError(StatusCode::kIOError, fmt::format("Error opening file: {}", path));
+    }
+    std::string output((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     return output;
   } catch (const std::exception &e) {
     return makeError(StatusCode::kIOError, fmt::format("Error when read {}: {}", path, e.what()));
@@ -15,7 +18,15 @@ Result<std::string> loadFile(const Path &path) {
 
 Result<Void> storeToFile(const Path &path, const std::string &content) {
   try {
-    boost::filesystem::save_string_file(path, content);
+    std::ofstream file(path);
+    if (!file) {
+      return makeError(StatusCode::kIOError, fmt::format("Error opening file for writing: {}", path));
+    }
+
+    file << content;
+    if (!file) {
+      return makeError(StatusCode::kIOError, fmt::format("Error writing to file: {}", path));
+    }
     return Void{};
   } catch (const std::exception &e) {
     return makeError(StatusCode::kIOError, fmt::format("Error when write to {}: {}", path, e.what()));

--- a/src/fuse/FuseOps.cc
+++ b/src/fuse/FuseOps.cc
@@ -2150,7 +2150,7 @@ void hf3fs_ioctl(fuse_req_t req,
         fuse_reply_err(req, EINVAL);
         return;
       }
-      if (name.has_branch_path()) {
+      if (name.has_parent_path()) {
         fuse_reply_err(req, EINVAL);
         return;
       }

--- a/tests/meta/TestCommon.cc
+++ b/tests/meta/TestCommon.cc
@@ -35,7 +35,7 @@ using hf3fs::meta::InodeId;
 
 static void print(const Path &path) {
   fmt::print("path {}\n", path);
-  fmt::print("abs {}, complete {}, relative {}\n", path.is_absolute(), path.is_absolute(), path.is_relative());
+  fmt::print("abs {}, relative {}\n", path.is_absolute(), path.is_relative());
   fmt::print("has root {}, {}\n", path.has_root_path(), path.root_path());
   fmt::print("has relative {}, {}\n", path.has_relative_path(), path.relative_path());
   fmt::print("has branch {}, {}\n", path.has_parent_path(), path.parent_path());

--- a/tests/meta/TestCommon.cc
+++ b/tests/meta/TestCommon.cc
@@ -35,17 +35,17 @@ using hf3fs::meta::InodeId;
 
 static void print(const Path &path) {
   fmt::print("path {}\n", path);
-  fmt::print("abs {}, complete {}, relative {}\n", path.is_absolute(), path.is_complete(), path.is_relative());
+  fmt::print("abs {}, complete {}, relative {}\n", path.is_absolute(), path.is_absolute(), path.is_relative());
   fmt::print("has root {}, {}\n", path.has_root_path(), path.root_path());
   fmt::print("has relative {}, {}\n", path.has_relative_path(), path.relative_path());
-  fmt::print("has branch {}, {}\n", path.has_parent_path(), path.branch_path());
+  fmt::print("has branch {}, {}\n", path.has_parent_path(), path.parent_path());
   fmt::print("has stem {}, {}\n", path.has_stem(), path.stem());
   fmt::print("has filename {}, {}, is dot {}, is dot dot {}\n",
              path.has_filename(),
              path.filename(),
              path.filename_is_dot(),
              path.filename_is_dot_dot());
-  fmt::print("has leaf {}, {}", path.has_leaf(), path.leaf());
+  fmt::print("has leaf {}, {}", !path.empty(), path.filename());
   fmt::print("size {}, components {}, first {}, last {}\n",
              path.size(),
              std::distance(path.begin(), path.end()),

--- a/tests/meta/store/ops/TestResolve.cc
+++ b/tests/meta/store/ops/TestResolve.cc
@@ -196,7 +196,7 @@ TYPED_TEST(TestResolve, pathRange) {
       auto path = PathAt("/a/b/c/d");
       Path trace;
       auto result = co_await PathResolveOp(*txn, aclCache, SUPER_USER, &trace).pathRange(path);
-      std::cout << "resolve " << *path.path << " -> " << trace << " " << trace.normalize() << std::endl;
+      std::cout << "resolve " << *path.path << " -> " << trace << " " << trace.lexically_normal() << std::endl;
       CO_ASSERT_OK(result);
       CO_ASSERT_TRUE(result->missing.empty()) << result->missing;
       CO_ASSERT_EQ(result->getParentId(), c.id);
@@ -208,7 +208,7 @@ TYPED_TEST(TestResolve, pathRange) {
       auto path = Path("/a/b/c/e");
       Path trace;
       auto result = co_await PathResolveOp(*txn, aclCache, SUPER_USER, &trace).pathRange(path);
-      std::cout << "resolve " << path << " -> " << trace << " " << trace.normalize() << std::endl;
+      std::cout << "resolve " << path << " -> " << trace << " " << trace.lexically_normal() << std::endl;
       CO_ASSERT_OK(result);
       CO_ASSERT_TRUE(result->missing.empty()) << result->missing;
       CO_ASSERT_EQ(result->getParentId(), c.id);
@@ -221,7 +221,7 @@ TYPED_TEST(TestResolve, pathRange) {
       Path trace;
       auto result = co_await PathResolveOp(*txn, aclCache, SUPER_USER, &trace).pathRange(path);
       CO_ASSERT_OK(result);
-      std::cout << "resolve " << *path.path << " -> " << trace << " " << trace.normalize() << std::endl;
+      std::cout << "resolve " << *path.path << " -> " << trace << " " << trace.lexically_normal() << std::endl;
       CO_ASSERT_TRUE(result->missing.empty()) << result->missing;
       CO_ASSERT_EQ(result->getParentId(), c.id);
       CO_ASSERT_EQ(result->dirEntry.value(), dEntry);


### PR DESCRIPTION
We met the following error while building 3FS.
```
/home/symious/testground/3fs/3fs/src/common/utils/FileUtils.cc:9:24: error: 'load_string_file' is deprecated: Use file IO streams instead [-Werror,-Wdeprecated-declarations]
    boost::filesystem::load_string_file(path, output);
                       ^
/usr/include/boost/filesystem/string_file.hpp:49:1: note: 'load_string_file' has been explicitly marked deprecated here
BOOST_FILESYSTEM_DETAIL_DEPRECATED("Use file IO streams instead")
^
/usr/include/boost/filesystem/config.hpp:73:49: note: expanded from macro 'BOOST_FILESYSTEM_DETAIL_DEPRECATED'
#define BOOST_FILESYSTEM_DETAIL_DEPRECATED(msg) BOOST_DEPRECATED(msg)
                                                ^
/usr/include/boost/config/compiler/clang.hpp:342:46: note: expanded from macro 'BOOST_DEPRECATED'
#define BOOST_DEPRECATED(msg) __attribute__((deprecated(msg)))
                                             ^
/home/symious/testground/3fs/3fs/src/common/utils/FileUtils.cc:18:24: error: 'save_string_file' is deprecated: Use file IO streams instead [-Werror,-Wdeprecated-declarations]
    boost::filesystem::save_string_file(path, content);
                       ^
/usr/include/boost/filesystem/string_file.hpp:37:1: note: 'save_string_file' has been explicitly marked deprecated here
BOOST_FILESYSTEM_DETAIL_DEPRECATED("Use file IO streams instead")
^
/usr/include/boost/filesystem/config.hpp:73:49: note: expanded from macro 'BOOST_FILESYSTEM_DETAIL_DEPRECATED'
#define BOOST_FILESYSTEM_DETAIL_DEPRECATED(msg) BOOST_DEPRECATED(msg)
                                                ^
/usr/include/boost/config/compiler/clang.hpp:342:46: note: expanded from macro 'BOOST_DEPRECATED'
#define BOOST_DEPRECATED(msg) __attribute__((deprecated(msg)))
```

The root cause is it's using the deprecated method of "boost::filesystem::load_string_file" and "boost::filesystem::save_string_file" (since Boost 1.76+).