### PR TITLE
Remove FIO_SYNCIO flag

### DIFF
--- a/benchmarks/fio_usrbio/hf3fs_usrbio.cpp
+++ b/benchmarks/fio_usrbio/hf3fs_usrbio.cpp
@@ -266,7 +266,7 @@ void get_ioengine(struct ioengine_ops **ioengine_ptr) {
 
     ioengine.name = "hf3fs_usrbio",
     ioengine.version = FIO_IOOPS_VERSION;
-    ioengine.flags = FIO_SYNCIO | FIO_NODISKUTIL;
+    ioengine.flags = FIO_NODISKUTIL;
     ioengine.init = hf3fs_usrbio_init;
     ioengine.queue = hf3fs_usrbio_queue;
     ioengine.commit = hf3fs_usrbio_commit;


### PR DESCRIPTION
We got the following note while doing fio benchmark.

```
note: both iodepth >= 1 and synchronous I/O engine are selected, queue depth will be capped at 1.
```

This PR is to enable the async IO for fio.