### PR TITLE
move nextAvail back as much as possible

### DIFF
--- a/src/common/utils/AtomicSharedPtrTable.h
+++ b/src/common/utils/AtomicSharedPtrTable.h
@@ -32,11 +32,11 @@ struct AvailSlots {
 
     std::lock_guard lock(mutex);
     if (idx == nextAvail - 1) {
-        nextAvail--;
-        while (free.find(nextAvail - 1) != free.end()) {
-            // move back next avail as much as possible
-            free.erase(--nextAvail);
-        }
+      nextAvail--;
+      while (free.find(nextAvail - 1) != free.end()) {
+          // move back next avail as much as possible
+          free.erase(--nextAvail);
+      }
     } else {
       free.insert(idx);
     }

--- a/src/common/utils/AtomicSharedPtrTable.h
+++ b/src/common/utils/AtomicSharedPtrTable.h
@@ -32,10 +32,11 @@ struct AvailSlots {
 
     std::lock_guard lock(mutex);
     if (idx == nextAvail - 1) {
-      while (free.find(--nextAvail) != free.end()) {
-        // move back next avail as much as possible
-        ;
-      }
+        nextAvail--;
+        while (free.find(nextAvail - 1) != free.end()) {
+            // move back next avail as much as possible
+            free.erase(--nextAvail);
+        }
     } else {
       free.insert(idx);
     }


### PR DESCRIPTION
The original code won't move the nextAvail.

Say we have 5 slots, and all allocated.
T1. nextAvail = 5, free = {}
T2. dealloc(2), nextAvail = 5, free = {2}
T3. dealloc(3), nextAvail = 5, free = {2, 3}
T4. dealloc(4)
  1. 4 == nextAvail - 1, so check while
  2. free.find(--nextAvail), which is free.find(4) is free.end(), so returned directly.

Or is it because of performance issue to remove the free.erase logic here? If so we don't need to while check here.