### PR TITLE
add build-essential to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ Install dependencies:
 # for Ubuntu 20.04.
 apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libdwarf-dev libunwind-dev \
   libaio-dev libgflags-dev libgoogle-glog-dev libgtest-dev libgmock-dev clang-format-14 clang-14 clang-tidy-14 lld-14 \
-  libgoogle-perftools-dev google-perftools libssl-dev libclang-rt-14-dev gcc-10 g++-10 libboost1.71-all-dev
+  libgoogle-perftools-dev google-perftools libssl-dev libclang-rt-14-dev gcc-10 g++-10 libboost1.71-all-dev build-essential
 
 # for Ubuntu 22.04.
 apt install cmake libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev libdwarf-dev libunwind-dev \
   libaio-dev libgflags-dev libgoogle-glog-dev libgtest-dev libgmock-dev clang-format-14 clang-14 clang-tidy-14 lld-14 \
-  libgoogle-perftools-dev google-perftools libssl-dev gcc-12 g++-12 libboost-all-dev
+  libgoogle-perftools-dev google-perftools libssl-dev gcc-12 g++-12 libboost-all-dev build-essential
 
 # for openEuler 2403sp1
 yum install cmake libuv-devel lz4-devel xz-devel double-conversion-devel libdwarf-devel libunwind-devel \


### PR DESCRIPTION
For a fresh new development environment, the `build-essential` package is required. Otherwise CMAKE error: `No CMAKE_C_COMPILER could be found` will occur. This is confirmed on Ubuntu distros.