### PR TITLE
fix OfflineTargetReq.targetId in ResyncWorker, fix #229

### DIFF
--- a/src/storage/sync/ResyncWorker.cc
+++ b/src/storage/sync/ResyncWorker.cc
@@ -279,7 +279,7 @@ CoTryTask<void> ResyncWorker::handleSync(VersionedChainId vChainId) {
     XLOG(CRITICAL, msg);
 
     OfflineTargetReq req;
-    req.targetId = targetId;
+    req.targetId = target->successor->targetInfo.targetId;
     req.force = true;
     CO_RETURN_AND_LOG_ON_ERROR(co_await components_.messenger.offlineTarget(*addrResult, req, &options));
 


### PR DESCRIPTION
The targetId should be successor's targetId, because the OfflineTargetReq is sent to successor.