### PR TITLE
Supports IB listening to RDMA traffic

### DIFF
--- a/src/common/net/Listener.cc
+++ b/src/common/net/Listener.cc
@@ -37,7 +37,7 @@ static bool checkNicType(std::string_view nic, Address::Type type) {
     case Address::IPoIB:
       return nic.starts_with("ib");
     case Address::RDMA:
-      return nic.starts_with("en") || nic.starts_with("eth") || nic.starts_with("bond") || nic.starts_with("xgbe");
+      return nic.starts_with("en") || nic.starts_with("eth") || nic.starts_with("bond") || nic.starts_with("xgbe") || nic.starts_with("ib");
     case Address::LOCAL:
       return nic.starts_with("lo");
     default:


### PR DESCRIPTION
When using the NVIDIA ConnectX InfiniBand network card, the IB network card is not supported to listen to RDMA-type traffic
A similar issue was raised by [https://github.com/deepseek-ai/3FS/issues/223](https://github.com/deepseek-ai/3FS/issues/223) and [https://github.com/deepseek-ai/3FS/issues/156](https://github.com/deepseek-ai/3FS/issues/156)
So adding support