### PR TITLE
FuseClients.cc: Change log level from INFO to DBG

### DIFF
--- a/src/fuse/FuseClients.cc
+++ b/src/fuse/FuseClients.cc
@@ -405,7 +405,7 @@ CoTask<void> FuseClients::periodicSyncScan() {
     co_return;
   }
 
-  XLOGF(INFO, "periodicSyncScan run");
+  XLOGF(DBG, "periodicSyncScan run");
   std::set<InodeId> dirty;
   {
     auto guard = dirtyInodes.lock();


### PR DESCRIPTION
The execution period of the periodicSyncScan function is between (0.35, 0.65). Setting the log level to info results in excessive logging. This patch changes the log level to DBG.