### PR TITLE
Fix index out of bounds issue in batch_remove

### DIFF
--- a/src/storage/chunk_engine/src/core/engine.rs
+++ b/src/storage/chunk_engine/src/core/engine.rs
@@ -657,26 +657,26 @@ impl Engine {
         max_count: u64,
     ) -> Result<u64> {
         let chunks = self.meta_store.query_chunks(begin, end, max_count)?;
-        let chunks_len = chunks.len();
+        let mut offset = 0;
+
         const BATCH_SIZE: Size = Size::mebibyte(1);
         let mut write_batch = RocksDB::new_write_batch();
-        let mut persist_end = 0;
         for (index, (chunk_id, meta)) in chunks.iter().enumerate() {
             if write_batch.size_in_bytes() >= BATCH_SIZE.0 as _ {
                 self.meta_store.write(write_batch, true)?;
-                for i in persist_end..index + 1 {
-                    self.meta_cache.remove(&chunks[i].0);
-                }
-                persist_end = index + 1;
                 write_batch = RocksDB::new_write_batch();
+                for (chunk_id, _) in &chunks[offset..index] {
+                    self.meta_cache.remove(chunk_id);
+                }
+                offset = index;
             }
             self.meta_store
                 .remove_mut(&chunk_id, &meta, &mut write_batch)?;
         }
         if !write_batch.is_empty() {
             self.meta_store.write(write_batch, true)?;
-            for i in persist_end..chunks_len {
-                self.meta_cache.remove(&chunks[i].0);
+            for (chunk_id, _) in &chunks[offset..] {
+                self.meta_cache.remove(chunk_id);
             }
         }
         Ok(chunks.len() as _)


### PR DESCRIPTION
When the write batch size exceeds the batch size, the current chunk ID has not been committed to the meta store. The meta cache should not delete the current chunk ID in this scenario. This PR fixes the issue.

See also #238 and #252.