### PR TITLE
add supoort for mellanox nic which name start with "p1*"

### DIFF
--- a/src/common/net/Listener.cc
+++ b/src/common/net/Listener.cc
@@ -33,11 +33,11 @@ namespace hf3fs::net {
 static bool checkNicType(std::string_view nic, Address::Type type) {
   switch (type) {
     case Address::TCP:
-      return nic.starts_with("en") || nic.starts_with("eth") || nic.starts_with("bond") || nic.starts_with("xgbe");
+      return nic.starts_with("en") || nic.starts_with("eth") || nic.starts_with("bond") || nic.starts_with("xgbe") || nic.starts_with("p1");
     case Address::IPoIB:
       return nic.starts_with("ib");
     case Address::RDMA:
-      return nic.starts_with("en") || nic.starts_with("eth") || nic.starts_with("bond") || nic.starts_with("xgbe");
+      return nic.starts_with("en") || nic.starts_with("eth") || nic.starts_with("bond") || nic.starts_with("xgbe") || nic.starts_with("p1");
     case Address::LOCAL:
       return nic.starts_with("lo");
     default:


### PR DESCRIPTION
fixes: https://github.com/deepseek-ai/3FS/issues/263