### PR TITLE
[bugfix] get_allocate_tasks: more than 3 allocator have compact tasks will cause crash

### DIFF
--- a/src/storage/chunk_engine/src/alloc/allocators.rs
+++ b/src/storage/chunk_engine/src/alloc/allocators.rs
@@ -105,7 +105,7 @@ impl Allocators {
             .sum()
     }
 
-    pub fn get_allocate_tasks(&self, max_reserved: u64) -> tinyvec::ArrayVec<[GroupId; 3]> {
+    pub fn get_allocate_tasks(&self, max_reserved: u64) -> tinyvec::ArrayVec<[GroupId; CHUNK_SIZE_NUMBER]> {
         self.vec
             .iter()
             .filter_map(|allocator| allocator.get_compact_task(max_reserved))


### PR DESCRIPTION
fix the magic number 3 to CHUNK_SIZE_NUMBER