### PR TITLE
Fix race condition in chunk removal and compaction leading to metadata corruption

### DIFF
--- a/src/storage/chunk_engine/src/core/engine.rs
+++ b/src/storage/chunk_engine/src/core/engine.rs
@@ -663,7 +663,7 @@ impl Engine {
         const BATCH_SIZE: Size = Size::mebibyte(1);
         let mut write_batch = RocksDB::new_write_batch();
         let mut entries = Vec::<EntryByRef<Bytes, [u8], ChunkArc>>::with_capacity(chunks.len());
-        for (_, (chunk_id, meta)) in chunks.iter().enumerate() {
+        for (chunk_id, meta) in chunks.iter() {
             if write_batch.size_in_bytes() >= BATCH_SIZE.0 as _ {
                 self.meta_store.write(write_batch, true)?;
                 // remove the entries from the cache and clear the vec.


### PR DESCRIPTION
## Issue

When performing chunk deletion alongside compaction in the `chunk_engine` of the storage component, metadata inconsistency issues can occur due to a race condition.

Specifically:

- A deleted chunk (`ck1`) may still appear in the metadata as if it exists.
- The position (`pos1`) previously used by `ck1` is later reused by another chunk (`ck2`).
- This results in an inconsistent state: `ck1 → pos1`, `ck2 → pos1`.

<img width="1098" height="665" alt="image" src="https://github.com/user-attachments/assets/9ddcb043-aeda-4422-acf8-df70e8490cf2" />

## Root Cause

The issue arises from a concurrency problem between:

- **Chunk removal** in `commit_chunk`
- **Position replace** in compaction's `move_chunk`

Both operations modify the `meta_store` and `meta_cache`, but their updates are not atomic and lack proper synchronization. For example:

- `commit_chunk` deletes `ck1` from the store but leaves it in the cache; 
https://github.com/deepseek-ai/3FS/blob/394583dbf08d2d4931f236217ccdfaaeba0c515b/src/storage/chunk_engine/src/core/engine.rs#L475-L480
- `move_chunk` checks the cache and mistakenly assumes `ck1` is valid;
https://github.com/deepseek-ai/3FS/blob/394583dbf08d2d4931f236217ccdfaaeba0c515b/src/storage/chunk_engine/src/core/engine.rs#L230-L240
- It then writes new metadata using stale information about `ck1`, causing corruption.

A similar issue also exists in `batch_remove`.
https://github.com/deepseek-ai/3FS/blob/394583dbf08d2d4931f236217ccdfaaeba0c515b/src/storage/chunk_engine/src/core/engine.rs#L666-L670

## Example Flow

| remove chunk1 | compact group: move chunk1 | chunk2 write |
| --- | --- | --- |
| In `commit_chunk`, check if `chunk.is_removed` |     |     |
| Delete metadata in `meta_store`: `ck1 -> pos1`, `pos1 -> ck1` |     |     |
|     | Acquire `meta_cache` lock |     |
|     | Check if `chunk1` exists in the cache. If yes: |     |
|     | Modify metadata in `meta_store`:<br> - Remove `ck1 -> pos1`, `pos1 -> ck1`<br> - Insert `ck1 -> pos2`, `pos2 -> ck1` |     |
|     | Update cache: `ck1 -> pos2` |     |
|     | Release `meta_cache` lock |     |
| Acquire `meta_cache` lock |     |     |
| Remove cache entry: `ChunkArc` reference count drops to zero, chunk is dereferenced, releasing `pos1` and `pos2` |     |     |
| Release `meta_cache` lock |     |     |
| `chunk1` no longer exists in cache, but metadata still contains `ck1 -> pos2`, `pos2 -> ck1` |     |     |
|     |     | Acquire `pos2`, insert metadata `ck2 -> pos2`, `pos2 -> ck2`, overwriting `pos2 -> ck1` |
| `chunk1` no longer exists in cache, but metadata still contains `ck1 -> pos2` |     |     |

## Solution

This PR introduces proper locking around `commit_chunk` and `batch_remove` operations to ensure all changes to `meta_cache` and `meta_store` are synchronized and atomic. This prevents race conditions and ensures consistent metadata across concurrent chunk removal and compaction's move chunk workflows.