### PR TITLE
fix potential inconsistency in commit chunk(s)

### DIFF
--- a/src/storage/chunk_engine/src/meta/meta_store.rs
+++ b/src/storage/chunk_engine/src/meta/meta_store.rs
@@ -355,6 +355,11 @@ impl MetaStore {
         })
     }
 
+    pub fn remove_writing_chunk(&self, chunk_id: &[u8], sync: bool) -> Result<()> {
+        let chunk_meta_key = MetaKey::writing_chunk_key(chunk_id);
+        self.rocksdb.delete(chunk_meta_key, sync)
+    }
+
     pub fn remove_writing_chunk_mut(&self, chunk_id: &[u8], write_batch: &mut rocksdb::WriteBatch) {
         write_batch.delete(MetaKey::writing_chunk_key(chunk_id));
     }


### PR DESCRIPTION
When performing deletion in commit_chunk, the original chunk may have been relocated by the background `compact_groups`. In this case, the latest chunk location should be obtained after locking to proceed with the commit. This PR fixes this issue.