### PR TITLE
loosen restrictions on chain version in batch read scenarios

### DIFF
--- a/src/storage/service/TargetMap.cc
+++ b/src/storage/service/TargetMap.cc
@@ -55,7 +55,7 @@ Result<const Target *> TargetMap::getTarget(TargetId targetId) const {
 Result<const Target *> TargetMap::getByChainId(VersionedChainId vChainId, bool allowOutdatedChainVer) const {
   CHECK_RESULT(targetId, getTargetId(vChainId.chainId));
   CHECK_RESULT(target, getTarget(targetId));
-  if (target->vChainId != vChainId && (!allowOutdatedChainVer || vChainId.chainVer > target->vChainId.chainVer)) {
+  if (target->vChainId != vChainId && !allowOutdatedChainVer) {
     auto msg = fmt::format("chain {} version mismatch request {} != local {}",
                            vChainId.chainId,
                            vChainId.chainVer,


### PR DESCRIPTION
In the context of batch read, if a client can initiate a read request to a server and the target status on the server side is valid, it means that under the current routing versions of the client and server, the read request is considered valid. Therefore, the additional chain version check has been removed.

Fix #340.