### PR TITLE
loosen restrictions on public state in batch read scenarios

### DIFF
--- a/src/fbs/storage/Common.h
+++ b/src/fbs/storage/Common.h
@@ -704,9 +704,7 @@ struct Target {
  public:
   Result<net::Address> getSuccessorAddr() const;
 
-  bool upToDate() const {
-    return localState == flat::LocalTargetState::UPTODATE && publicState == flat::PublicTargetState::SERVING;
-  }
+  bool upToDate() const { return localState == flat::LocalTargetState::UPTODATE; }
 
   bool unrecoverableOffline() const { return diskError || offlineUponUserRequest; }
 };


### PR DESCRIPTION
According to #344, it is indeed unnecessary to check the public state of the target in batch read scenarios.

Fix #344.