### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-dev-docker-image.yml
+++ b/.github/workflows/build-dev-docker-image.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Log in to the Container registry
-      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -30,13 +30,13 @@ jobs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Build and push Docker image
       id: push
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
       with:
         context: .
         file: ./dockerfile/dev.dockerfile


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `docker/build-push-action` | [`3b5e802`](https://github.com/docker/build-push-action/commit/3b5e8027fcad23fda98b2e3ac259d8d67585f671) | [`2634353`](https://github.com/docker/build-push-action/commit/263435318d21b8e681c14492fe198d362a7d2c83) | [Release](https://github.com/docker/build-push-action/releases/tag/v6) | build-dev-docker-image.yml |
| `docker/login-action` | [`65b78e6`](https://github.com/docker/login-action/commit/65b78e6e13532edd9afa3aa52ac7964289d1a9c1) | [`5e57cd1`](https://github.com/docker/login-action/commit/5e57cd118135c172c3672efd75eb46360885c0ef) | [Release](https://github.com/docker/login-action/releases/tag/v3) | build-dev-docker-image.yml |
| `docker/metadata-action` | [`9ec57ed`](https://github.com/docker/metadata-action/commit/9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7) | [`c299e40`](https://github.com/docker/metadata-action/commit/c299e40c65443455700f0fdfc63efafe5b349051) | [Release](https://github.com/docker/metadata-action/releases/tag/v5) | build-dev-docker-image.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
