### PR TITLE
fix: TCP connection leak and metric overflow (#365, #366)

### DIFF
--- a/src/common/net/ServiceGroup.cc
+++ b/src/common/net/ServiceGroup.cc
@@ -48,7 +48,9 @@ void ServiceGroup::stopAndJoin() {
 CoTask<void> ServiceGroup::checkConnectionsRegularly() {
   while (true) {
     XLOGF(DBG9, "server@{} check connections", fmt::ptr(this));
+    // Check both RDMA and TCP connections for expiration
     ioWorker().checkConnections(Address{0, 0, Address::RDMA}, config_.connection_expiration_time());
+    ioWorker().checkConnections(Address{0, 0, Address::TCP}, config_.connection_expiration_time());
     co_await folly::coro::sleep(config_.check_connections_interval().asMs());
   }
 }

--- a/src/common/net/TransportPool.cc
+++ b/src/common/net/TransportPool.cc
@@ -141,7 +141,9 @@ std::pair<TransportPtr, bool> TransportPool::get(Address addr, IOWorker &io_work
         // 3. create a new transport. still protected by mutex.
         transport = Transport::create(addr, io_worker);
         set.add(transport, idx);
-        acceptedCountRecorder.set(++acceptedCount);
+        // Increment connectedCount for outgoing connections (addr.ip != 0)
+        // to match the decrement in remove() for symmetry
+        connectedCountRecorder.set(++connectedCount);
         cached = transport;
         return std::make_pair(std::move(transport), true);
       },


### PR DESCRIPTION
## Summary
- Fix TCP connection leak (#365): Add TCP connection cleanup in `checkConnectionsRegularly()`
- Fix metric overflow (#366): Increment `connectedCount` when creating new outgoing connections

## Changes
1. **ServiceGroup.cc**: Add TCP connection cleanup alongside RDMA in `checkConnectionsRegularly()`
2. **TransportPool.cc**: Increment `connectedCount` when creating new connections to match decrement in `remove()`

## Test plan
- [x] Verify idle TCP connections are properly released when reducing `max_connections`
- [x] Verify `common.net.connected_count` metric doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)