### PR TITLE
Fix connected_count metric underflow in TransportPool::get()

### DIFF
--- a/src/common/net/TransportPool.cc
+++ b/src/common/net/TransportPool.cc
@@ -141,7 +141,11 @@ std::pair<TransportPtr, bool> TransportPool::get(Address addr, IOWorker &io_work
         // 3. create a new transport. still protected by mutex.
         transport = Transport::create(addr, io_worker);
         set.add(transport, idx);
-        acceptedCountRecorder.set(++acceptedCount);
+        if (addr.ip == 0) {
+          acceptedCountRecorder.set(++acceptedCount);
+        } else {
+          connectedCountRecorder.set(++connectedCount);
+        }
         cached = transport;
         return std::make_pair(std::move(transport), true);
       },


### PR DESCRIPTION
## Summary

This PR fixes the `common.net.connected_count` metric underflow bug reported in #366.

## Root Cause

In `TransportPool::get()`, when creating a new transport, the code always incremented `acceptedCount` regardless of the `addr.ip` value:

```cpp
// Before (bug)
transport = Transport::create(addr, io_worker);
set.add(transport, idx);
acceptedCountRecorder.set(++acceptedCount);  // Always increments acceptedCount
```

However, `TransportPool::add()` and `TransportPool::remove()` correctly check `addr.ip`:
- `addr.ip == 0`: Use `acceptedCount` (incoming/accepted connections)
- `addr.ip != 0`: Use `connectedCount` (outgoing/connected connections)

## The Bug

1. `get()` creates a transport with `addr.ip != 0` → increments `acceptedCount` (wrong!)
2. Later, `remove()` is called for that transport → decrements `connectedCount` (correct)
3. `connectedCount` underflows → wraps to `UINT32_MAX` (4294967295)

## Fix

Added the same `addr.ip` check that exists in `add()` and `remove()`:

```cpp
// After (fix)
transport = Transport::create(addr, io_worker);
set.add(transport, idx);
if (addr.ip == 0) {
  acceptedCountRecorder.set(++acceptedCount);
} else {
  connectedCountRecorder.set(++connectedCount);
}
```