### PR TITLE
fix: Remove race condition in memory allocator initialization

### DIFF
--- a/src/memory/common/GlobalMemoryAllocator.cc
+++ b/src/memory/common/GlobalMemoryAllocator.cc
@@ -14,7 +14,6 @@ namespace hf3fs::memory {
 #ifdef OVERRIDE_CXX_NEW_DELETE
 
 static std::once_flag gInitOnce;
-static bool gAllocatorInited = false;
 static MemoryAllocatorInterface *gAllocator = nullptr;
 static thread_local hf3fs::memory::AllocatedMemoryCounter gMemCounter;
 
@@ -73,10 +72,7 @@ exit:
 }
 
 void *allocate(size_t size) {
-  if (!gAllocatorInited) {
-    std::call_once(gInitOnce, loadMemoryAllocatorLib);
-    gAllocatorInited = true;
-  }
+  std::call_once(gInitOnce, loadMemoryAllocatorLib);
 
 #ifdef SAVE_ALLOCATE_SIZE
   const size_t headerSize = kHeaderSize;
@@ -130,10 +126,7 @@ void deallocate(void *mem) {
 }
 
 void *memalign(size_t alignment, size_t size) {
-  if (!gAllocatorInited) {
-    std::call_once(gInitOnce, loadMemoryAllocatorLib);
-    gAllocatorInited = true;
-  }
+  std::call_once(gInitOnce, loadMemoryAllocatorLib);
 
 #ifdef SAVE_ALLOCATE_SIZE
   const size_t alignedHeaderSize = std::max(alignment, kHeaderSize);


### PR DESCRIPTION
## Summary

- Fixes #315: Potential Race Condition in Memory Allocator Initialization
- Removes the unsynchronized `gAllocatorInited` flag that caused a race condition
- Relies solely on `std::call_once` which provides proper thread-safety guarantees

## Problem

The original code had a race condition in `GlobalMemoryAllocator.cc`:

```cpp
static bool gAllocatorInited = false;  // Plain bool, not atomic

void *allocate(size_t size) {
  if (!gAllocatorInited) {  // Multiple threads can pass this check
    std::call_once(gInitOnce, loadMemoryAllocatorLib);
    gAllocatorInited = true;  // Can be reordered with gAllocator write
  }
```

**Issues:**
1. `gAllocatorInited` is a plain `bool`, not atomic - no synchronization
2. Instruction reordering: `gAllocatorInited = true` can execute before `std::call_once` fully completes
3. Memory visibility: other threads may see `gAllocatorInited = true` while `gAllocator` is still uninitialized

## Solution

Remove the redundant flag and rely solely on `std::call_once`:

```cpp
void *allocate(size_t size) {
  std::call_once(gInitOnce, loadMemoryAllocatorLib);
```

**Why this works:**
- `std::call_once` provides full happens-before guarantees (C++11 standard)
- After first execution, `call_once` becomes a fast single atomic load (efficient fast-path)
- No performance degradation - simpler code with same or better performance

## Test plan

- [ ] Verify existing unit tests pass
- [ ] Code review for thread-safety correctness
- [ ] The fix is minimal and follows the principle of relying on well-tested standard library primitives

🤖 Generated with [Claude Code](https://claude.com/claude-code)