### PR TITLE
refactor: Add empty() method to TagSet and use it for emptiness checks

### DIFF
--- a/src/common/monitor/Sample.h
+++ b/src/common/monitor/Sample.h
@@ -39,6 +39,7 @@ class TagSet {
   std::map<String, String> asMap() const { return {begin(), end()}; }
 
   size_t size() const { return tag_set_.size(); }
+  bool empty() const { return tag_set_.empty(); }
 
   Iterator begin() { return tag_set_.begin(); }
   Iterator end() { return tag_set_.end(); }

--- a/src/common/monitor/ScopedMetricsWriter.h
+++ b/src/common/monitor/ScopedMetricsWriter.h
@@ -15,7 +15,7 @@ class ScopedCounterWriter {
         value_(value),
         tagSet_(tagSet) {
     int64_t currentCounter = counter_.fetch_add(value_) + value_;
-    if (tagSet.size() > 0)
+    if (!tagSet.empty())
       recorder_.addSample(currentCounter, tagSet_);
     else
       recorder_.addSample(currentCounter);
@@ -32,7 +32,7 @@ class ScopedCounterWriter {
 
   ~ScopedCounterWriter() {
     int64_t currentCounter = counter_.fetch_add(-value_) - value_;
-    if (tagSet_.size() > 0)
+    if (!tagSet_.empty())
       recorder_.addSample(currentCounter, tagSet_);
     else
       recorder_.addSample(currentCounter);
@@ -56,7 +56,7 @@ class ScopedLatencyWriter {
       : ScopedLatencyWriter(recorder, instance.empty() ? monitor::TagSet() : monitor::instanceTagSet(instance)) {}
 
   ~ScopedLatencyWriter() {
-    if (tagSet_.size() > 0)
+    if (!tagSet_.empty())
       recorder_.addSample(getElapsedTime(), tagSet_);
     else
       recorder_.addSample(getElapsedTime());


### PR DESCRIPTION
## Summary

- Adds `empty()` method to `TagSet` class for consistent container interface
- Replaces `.size() > 0` checks with `!.empty()` in `ScopedMetricsWriter`

## Motivation

This follows the clang-tidy `readability-container-size-empty` guideline which recommends using `empty()` instead of comparing `size()` to zero.

Benefits:
- **Readability**: `!.empty()` is more idiomatic and clearer than `.size() > 0`
- **Consistency**: Aligns `TagSet` with standard container interfaces
- **Future-proofing**: `empty()` can be more efficient than `size() == 0` for some container types

## Changes

1. **`src/common/monitor/Sample.h`**: Added `bool empty() const` method to `TagSet` class
2. **`src/common/monitor/ScopedMetricsWriter.h`**: Replaced 3 instances of `.size() > 0` with `!.empty()`

## Test plan

- [ ] Existing tests should pass (no behavioral change)
- [ ] Code review for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)