### PR TITLE
Fix strict aliasing violations in Address

### DIFF
--- a/src/common/utils/Address.h
+++ b/src/common/utils/Address.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bit>
+#include <cstring>
 #include <fmt/core.h>
 #include <folly/IPAddressV4.h>
 #include <folly/SocketAddress.h>
@@ -14,13 +16,13 @@ namespace hf3fs::net {
 constexpr const char *kUnixDomainSocketPrefix[] = {nullptr, "/tmp/domain_socket."};
 
 struct Address {
-  uint32_t ip{};
+  uint32_t ip{}; // Stored in Network Byte Order
   uint16_t port{};
   enum Type : uint16_t { TCP, RDMA, IPoIB, LOCAL, UNIX };
   Type type = Type::TCP;
   using is_serde_copyable = void;
 
-  explicit Address(uint64_t addr = 0) { *reinterpret_cast<uint64_t *>(this) = addr; }
+  explicit Address(uint64_t addr = 0) { *this = std::bit_cast<Address>(addr); }
   Address(uint32_t ip, uint16_t port, Type type)
       : ip(ip),
         port(port),
@@ -32,19 +34,20 @@ struct Address {
 
   bool operator==(const Address &other) const { return uint64_t(*this) == uint64_t(other); }
 
-  Address tcp() { return Address{ip, port, Type::TCP}; }
+  Address tcp() const { return Address{ip, port, Type::TCP}; }
 
-  operator uint64_t() const { return *reinterpret_cast<const uint64_t *>(this); }
+  operator uint64_t() const { return std::bit_cast<uint64_t>(*this); }
   std::string str() const {
-    auto &arr = *reinterpret_cast<const std::array<uint8_t, 4> *>(this);
+    auto arr = std::bit_cast<std::array<uint8_t, 4>>(ip);
     return fmt::format("{}://{}.{}.{}.{}:{}", magic_enum::enum_name(type), arr[0], arr[1], arr[2], arr[3], port);
   }
   std::string toString() const { return str(); }
   std::string serdeToReadable() const { return toString(); }
   std::string ipStr() const {
-    auto &arr = *reinterpret_cast<const std::array<uint8_t, 4> *>(this);
+    auto arr = std::bit_cast<std::array<uint8_t, 4>>(ip);
     return fmt::format("{}.{}.{}.{}", arr[0], arr[1], arr[2], arr[3]);
   }
+
   Result<std::string> domainSocketPath() const {
     if (UNLIKELY(type != Type::UNIX)) {
       return makeError(StatusCode::kInvalidFormat, "invalid type: {} != UNIX", type);
@@ -55,29 +58,24 @@ struct Address {
     return fmt::format("{}{}", kUnixDomainSocketPrefix[ip], port);
   }
 
-  folly::SocketAddress toFollyAddress() const {
-    if (UNLIKELY(type == Type::UNIX)) {
-      folly::SocketAddress ret;
-      auto result = domainSocketPath();
-      if (LIKELY(bool(result))) {
-        ret.setFromPath(*result);
-      }
-      return ret;
-    }
-    return folly::SocketAddress{folly::IPAddressV4::fromLong(ip).toAddr(), port};
-  }
   folly::IPAddressV4 toFollyIP() const { return folly::IPAddressV4::fromLong(ip); }
-
+  folly::SocketAddress toFollyAddress() const {
+    if (UNLIKELY(type == UNIX)) {
+      auto path = domainSocketPath();
+      return path ? folly::SocketAddress::makeFromPath(*path) : folly::SocketAddress{};
+    }
+    return folly::SocketAddress{toFollyIP().toAddr(), port};
+  }
   static Address fromFollyAddress(const folly::SocketAddress &follyAddr, Type type) {
     auto IPAddr = follyAddr.getIPAddress();
     return Address{IPAddr.isV4() ? IPAddr.asV4().toLong() : 0, follyAddr.getPort(), type};
   }
 
   static Address fromString(std::string_view sv, Type type) {
-    Address addr(0, 0, type);
-    auto &arr = *reinterpret_cast<std::array<uint8_t, 4> *>(&addr);
-    auto r = scn::scan(sv, "{}.{}.{}.{}:{}", arr[0], arr[1], arr[2], arr[3], addr.port);
-    return r ? addr : Address{};
+    std::array<uint8_t, 4> arr;
+    uint16_t port;
+    auto r = scn::scan(sv, "{}.{}.{}.{}:{}", arr[0], arr[1], arr[2], arr[3], port);
+    return r ? Address{std::bit_cast<uint32_t>(arr), port, type} : Address{};
   }
 
   static Address fromString(std::string_view sv) {


### PR DESCRIPTION
Replaced reinterpret_cast with std::bit_cast.

The previous implementation used reinterpret_cast to treat the Address struct as a uint64_t or an array of bytes. 
Which could effectively work but violate C++ strict aliasing rules.
With C++20, these low-level bitwise reinterpretations could be safely performed via std::bit_cast.

While std::bit_cast is conceptually std::memcpy underhood, but it could be optimzed by compilers in many cases.
The compiler generates identical assembly code for simple cases:
https://godbolt.org/z/d7j5YYKcj