### PR TITLE
fix(fuse): fix double-reply and null-deref in iovs/addIoRing error path

### DIFF
--- a/src/fuse/FuseOps.cc
+++ b/src/fuse/FuseOps.cc
@@ -1234,7 +1234,8 @@ void hf3fs_symlink(fuse_req_t req, const char *link, fuse_ino_t fparent, const c
                                        ior->ioDepth,
                                        *ior->iora);
           if (!res2) {
-            handle_error(req, res);
+            handle_error(req, res2);
+            return;
           }
           // record the ior index for later removal
           res->second->iorIndex = *res2;

--- a/src/fuse/FuseOps.cc
+++ b/src/fuse/FuseOps.cc
@@ -1235,6 +1235,11 @@ void hf3fs_symlink(fuse_req_t req, const char *link, fuse_ino_t fparent, const c
                                        *ior->iora);
           if (!res2) {
             handle_error(req, res2);
+            // rollback the successful addIov before returning
+            auto rmRes = d.iovs.rmIov(name, userInfo);
+            if (rmRes.hasError()) {
+              XLOGF(ERR, "failed to rollback iov after addIoRing failure: {}", rmRes.error());
+            }
             return;
           }
           // record the ior index for later removal


### PR DESCRIPTION
What: In the FUSE symlink path for the iovs special directory, when addIoRing fails after a successful addIov, the code now passes the addIoRing result (res2) into handle_error instead of the addIoV success (res), and returns immediately afterward.

Why: So the client gets the correct error, and the handler does not call fuse_reply_entry after already replying via handle_error (avoids a double reply and unsafe follow-on logic on the error path).