### PR TITLE
fix(data-placement): normalize peer recovery traffic constraints

### DIFF
--- a/deploy/data_placement/src/model/data_placement.py
+++ b/deploy/data_placement/src/model/data_placement.py
@@ -252,9 +252,10 @@ class DataPlacementModel(object):
 
     def calc_peer_recovery_traffic(model, disk, peer):
       if self.qlinearize:
-        return po.quicksum(model.disk_in_same_group[disk,peer,group] for group in model.groups)
+        traffic = po.quicksum(model.disk_in_same_group[disk,peer,group] for group in model.groups)
       else:
-        return po.quicksum(calc_disk_in_same_group(model, disk, peer, group) for group in model.groups)
+        traffic = po.quicksum(calc_disk_in_same_group(model, disk, peer, group) for group in model.groups)
+      return traffic * self.recovery_traffic_factor / (self.group_size - 1)
 
     def peer_recovery_traffic_upper_bound(model, disk, peer):
       if self.balanced_incomplete_block_design:

--- a/deploy/data_placement/test/test_model.py
+++ b/deploy/data_placement/test/test_model.py
@@ -71,6 +71,19 @@ def test_solve_placement_model_v25(chain_table_type, num_nodes, group_size):
   )
   model.run(pyomo_solver="appsi_highs", max_timelimit=30, auto_relax=True)
 
+@pytest.mark.skipif(importlib.util.find_spec("highspy") is None, reason="cannot find solver")
+def test_solve_chain_replication_bibd_with_highs(tmp_path):
+  model = DataPlacementModel(
+    chain_table_type="CR",
+    num_nodes=4,
+    num_targets_per_disk=3,
+    group_size=3,
+    bibd_only=True,
+    qlinearize=True,
+    relax_lb=0,
+  )
+  model.solve(pyomo_solver="appsi_highs", output_path=str(tmp_path))
+
 @pytest.mark.parametrize('placement_params', placement_params)
 @pytest.mark.skipif(importlib.util.find_spec("highspy") is None, reason="cannot find solver")
 def test_solve_rebalance_model(placement_params):


### PR DESCRIPTION
Fixes #318.

`calc_peer_recovery_traffic` currently returns the number of groups shared by a disk pair, while `get_peer_traffic` and `check_solution` use normalized recovery traffic:

`shared_groups * recovery_traffic_factor / (group_size - 1)`

This change uses the same unit in the Pyomo constraints. The EC expression is algebraically unchanged because its recovery factor is `group_size - 1`; CR now accounts for recovery traffic being split across the other group members.

The regression test uses the 2-(4,3,2) CR BIBD case. It is infeasible with the previous bound and feasible after normalization.

Tested with:
- `pytest test/test_model.py` (18 passed)