### PR TITLE
fix(packaging): remove git dependency from package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,9 @@ import sys
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 #import setuptools_scm as stscm
-import subprocess
 
 #version = stscm.get_version(root=".", relative_to=__file__)
-rev = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').rstrip()
-version = "1.2.9+" + rev
+version = "1.2.9"
 print('package version', version)
         
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+
+def setup_version(source_dir, env=None):
+  result = subprocess.run(
+    [sys.executable, "setup.py", "--version"],
+    cwd=source_dir,
+    env=env,
+    capture_output=True,
+    text=True,
+  )
+  assert result.returncode == 0, result.stderr
+  return result.stdout.strip().splitlines()[-1]
+
+
+def test_sdist_version_without_git(tmp_path):
+  source_dir = tmp_path / "source"
+  source_dir.mkdir()
+  shutil.copy(Path(__file__).parents[1] / "setup.py", source_dir)
+  package_dir = source_dir / "hf3fs_fuse"
+  package_dir.mkdir()
+  (package_dir / "__init__.py").touch()
+
+  subprocess.run(["git", "init", "-q"], cwd=source_dir, check=True)
+  subprocess.run(["git", "add", "."], cwd=source_dir, check=True)
+  subprocess.run(
+    [
+      "git", "-c", "user.name=3FS test", "-c", "user.email=test@example.com",
+      "commit", "-qm", "test source",
+    ],
+    cwd=source_dir,
+    check=True,
+  )
+
+  source_version = setup_version(source_dir)
+  dist_dir = tmp_path / "dist"
+  subprocess.run(
+    [sys.executable, "setup.py", "sdist", "--dist-dir", str(dist_dir)],
+    cwd=source_dir,
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+
+  unpack_dir = tmp_path / "unpacked"
+  with tarfile.open(next(dist_dir.glob("*.tar.gz"))) as archive:
+    archive.extractall(unpack_dir)
+  unpacked_source = next(unpack_dir.iterdir())
+
+  env = os.environ.copy()
+  env["GIT_CEILING_DIRECTORIES"] = str(unpacked_source)
+  unpacked_version = setup_version(unpacked_source, env)
+  package_info = next(unpacked_source.glob("*.egg-info/PKG-INFO")).read_text()
+
+  assert source_version == unpacked_version == "1.2.9"
+  assert "Version: 1.2.9\n" in package_info


### PR DESCRIPTION
Addresses #343.

The generated source distribution runs `git rev-parse` from `setup.py`, but an unpacked sdist has no `.git` directory. That makes even package metadata commands fail before the native extension build starts.

This removes the unused revision suffix and keeps the package version at `1.2.9`, matching the published sdist metadata. The regression test builds an sdist from a temporary Git checkout, extracts it outside Git, and verifies that `setup.py --version` and `PKG-INFO` both report `1.2.9`.

This intentionally makes source-checkout metadata match the published version instead of adding a local `+<sha>` suffix.

Tested with:
- `pytest tests/test_setup.py` (1 passed)