### PR TITLE
fix(python): avoid userdata reference cycle in FUSE demo

### DIFF
--- a/hf3fs_fuse/fuse_demo.py
+++ b/hf3fs_fuse/fuse_demo.py
@@ -17,13 +17,14 @@ register_fd(fd) # must register after open to use usrbio
 # Read file
 ios = [(iov[:512], fd, 512), (iov[512:], fd, 0)] # iov, fd, offset
 for io in ios:
-    ior.prepare(io[0], True, io[1], io[2], userdata=io) # iov, for_read, fd, offset, userdata
+    expected_size = len(memoryview(io[0]))
+    ior.prepare(io[0], True, io[1], io[2], userdata=expected_size) # iov, for_read, fd, offset, userdata
     # Only for_read == True is allowed, because ior has for_read == True
-    # userdata must be a referenced python object, we reference io in the list ios, so it will not be sent to GC
+    # userdata is kept alive until completion; avoid referencing the iovec to prevent a cycle
 resv = ior.submit().wait(min_results=2)
 for res in resv:
     print(res.result)
-    assert res.result == len(memoryview(res.userdata[0])) # Check read length is correct
+    assert res.result == res.userdata # Check read length is correct
 
 # Close file
 deregister_fd(fd) # must deregister before close

--- a/src/lib/py/usrbio_binding.cc
+++ b/src/lib/py/usrbio_binding.cc
@@ -319,7 +319,7 @@ PYBIND11_MODULE(hf3fs_py_usrbio, m) {
               read: True / False，需与 ioring 的参数一致
               fd: 文件描述符
               off: 文件读取或写入偏移量
-              userdata: 默认为 None，可以指定一个 Python object，用户需确保该 object 不会被垃圾回收
+              userdata: 默认为 None，可以指定一个 Python object。该对象会被保持至操作完成。为避免引用环，userdata 不应直接或间接引用 iov
           )")
       .def(
           "submit",


### PR DESCRIPTION
Fixes #386.

The FUSE demo passes the full io tuple as userdata. That tuple contains the same iovec wrapper being prepared, while the C++ iov retains userdata through completion. This creates a wrapper -> C++ iov -> tuple -> wrapper cycle across the Python/C++ boundary.

Pass the expected byte count as scalar userdata instead, preserving the existing completion check without retaining the wrapper. Also clarify the userdata lifetime contract in the binding documentation.

Validation:
- Python source compilation
- static red/green check for the iovec-containing userdata path
- git diff --check

I could not run the FUSE/RDMA path locally. This does not change usrbio runtime ownership and does not address the separate prepare() error path.