### PR TITLE
fix(python): release userdata reference when prepare fails

### DIFF
--- a/src/lib/py/usrbio_binding.cc
+++ b/src/lib/py/usrbio_binding.cc
@@ -288,17 +288,20 @@ PYBIND11_MODULE(hf3fs_py_usrbio, m) {
             //       iov->size);
 
             userdata.inc_ref();
-            py::gil_scoped_release gr;
-
-            auto res = hf3fs_prep_io(self.get(),
-                                     (iov->base_iov ? iov->base_iov : iov).get(),
-                                     read,
-                                     iov->base,
-                                     fd,
-                                     off,
-                                     iov->size,
-                                     (void *)userdata.ptr());
+            int res;
+            {
+              py::gil_scoped_release gr;
+              res = hf3fs_prep_io(self.get(),
+                                  (iov->base_iov ? iov->base_iov : iov).get(),
+                                  read,
+                                  iov->base,
+                                  fd,
+                                  off,
+                                  iov->size,
+                                  (void *)userdata.ptr());
+            }
             if (res < 0) {
+              userdata.dec_ref();
               throw OSException{-res};
             }
 


### PR DESCRIPTION
The Python binding retains userdata manually so an asynchronous completion can return it later. When hf3fs_prep_io() returns a negative errno, no completion will be produced, but the retained reference was previously left behind.

Limit the GIL release to the native prepare call and release the manual reference on the error path after the GIL has been restored. The successful prepare/completion ownership path is unchanged.

This is separate from the userdata/iov reference cycle addressed by #421.

Validation:
- static red/green reference-lifetime audit across all negative return paths
- verified that error cleanup runs after GIL restoration
- git diff --check

I could not run the 3FS/FUSE integration path locally.