### PR TITLE
fix(fuse): clean up partial read setup

### DIFF
--- a/hf3fs_fuse/io.py
+++ b/hf3fs_fuse/io.py
@@ -88,10 +88,16 @@ def read_file(fn, hf3fs_mount_point=None, block_size=1 << 30, off=0, priority=No
         hf3fs_mount_point = extract_mount_point(fn)
 
     bufs = []
+    fd = None
+    fd_registered = False
+    shm = None
+    iov = None
+    ior = None
 
     try:
         fd = os.open(fn, os.O_RDONLY)
         register_fd(fd)
+        fd_registered = True
         shm = multiprocessing.shared_memory.SharedMemory(size=block_size, create=True)
         iov = make_iovec(shm, hf3fs_mount_point)
         ior = make_ioring(hf3fs_mount_point, 1, priority=priority)
@@ -131,9 +137,12 @@ def read_file(fn, hf3fs_mount_point=None, block_size=1 << 30, off=0, priority=No
         else:
             return b''.join(bufs)
     finally:
-        deregister_fd(fd)
-        os.close(fd)
+        if fd_registered:
+            deregister_fd(fd)
+        if fd is not None:
+            os.close(fd)
         del ior
         del iov
-        shm.close()
-        shm.unlink()
+        if shm is not None:
+            shm.close()
+            shm.unlink()

--- a/tests/fuse/test_hf3fs_fuse_io.py
+++ b/tests/fuse/test_hf3fs_fuse_io.py
@@ -53,6 +53,25 @@ def test_read_file_does_not_deregister_failed_registration(io_module, monkeypatc
     close.assert_called_once_with(17)
 
 
+def test_read_file_releases_fd_after_shared_memory_failure(io_module, monkeypatch):
+    module, native = io_module
+    monkeypatch.setattr(module.os, "open", Mock(return_value=19))
+    close = Mock()
+    monkeypatch.setattr(module.os, "close", close)
+    error = OSError("shared memory failed")
+    monkeypatch.setattr(
+        module.multiprocessing.shared_memory,
+        "SharedMemory",
+        Mock(side_effect=error),
+    )
+
+    with pytest.raises(OSError, match="shared memory failed"):
+        module.read_file("input", hf3fs_mount_point="/3fs", block_size=8)
+
+    native.deregister_fd.assert_called_once_with(19)
+    close.assert_called_once_with(19)
+
+
 def test_read_file_releases_resources_after_iovec_failure(io_module, monkeypatch):
     module, native = io_module
     native.register_fd.return_value = None
@@ -74,6 +93,31 @@ def test_read_file_releases_resources_after_iovec_failure(io_module, monkeypatch
 
     native.deregister_fd.assert_called_once_with(23)
     close.assert_called_once_with(23)
+    shared_memory.close.assert_called_once_with()
+    shared_memory.unlink.assert_called_once_with()
+
+
+def test_read_file_releases_resources_after_ioring_failure(io_module, monkeypatch):
+    module, native = io_module
+    monkeypatch.setattr(module.os, "open", Mock(return_value=27))
+    close = Mock()
+    monkeypatch.setattr(module.os, "close", close)
+
+    shared_memory = Mock()
+    shared_memory.buf = bytearray(8)
+    monkeypatch.setattr(
+        module.multiprocessing.shared_memory,
+        "SharedMemory",
+        Mock(return_value=shared_memory),
+    )
+    monkeypatch.setattr(module, "make_iovec", Mock(return_value=shared_memory.buf))
+    monkeypatch.setattr(module, "make_ioring", Mock(side_effect=RuntimeError("ioring failed")))
+
+    with pytest.raises(RuntimeError, match="ioring failed"):
+        module.read_file("input", hf3fs_mount_point="/3fs", block_size=8)
+
+    native.deregister_fd.assert_called_once_with(27)
+    close.assert_called_once_with(27)
     shared_memory.close.assert_called_once_with()
     shared_memory.unlink.assert_called_once_with()
 

--- a/tests/fuse/test_hf3fs_fuse_io.py
+++ b/tests/fuse/test_hf3fs_fuse_io.py
@@ -1,0 +1,107 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def io_module(monkeypatch):
+    native = types.ModuleType("hf3fs_py_usrbio")
+    native.register_fd = Mock()
+    native.deregister_fd = Mock()
+    native.force_fsync = Mock()
+    native.extract_mount_point = Mock(return_value="/3fs")
+    native.hardlink = Mock()
+    native.punch_hole = Mock()
+    native.iovec = Mock()
+    native.ioring = Mock()
+
+    monkeypatch.setitem(sys.modules, "hf3fs_py_usrbio", native)
+    sys.modules.pop("hf3fs_fuse.io", None)
+    module = importlib.import_module("hf3fs_fuse.io")
+    yield module, native
+    sys.modules.pop("hf3fs_fuse.io", None)
+
+
+def test_read_file_preserves_open_error(io_module, monkeypatch):
+    module, native = io_module
+    error = FileNotFoundError("missing input")
+    monkeypatch.setattr(module.os, "open", Mock(side_effect=error))
+
+    with pytest.raises(FileNotFoundError, match="missing input"):
+        module.read_file("missing")
+
+    native.register_fd.assert_not_called()
+    native.deregister_fd.assert_not_called()
+
+
+def test_read_file_does_not_deregister_failed_registration(io_module, monkeypatch):
+    module, native = io_module
+    error = RuntimeError("registration failed")
+    native.register_fd.side_effect = error
+    monkeypatch.setattr(module.os, "open", Mock(return_value=17))
+    close = Mock()
+    monkeypatch.setattr(module.os, "close", close)
+
+    with pytest.raises(RuntimeError, match="registration failed"):
+        module.read_file("input")
+
+    native.deregister_fd.assert_not_called()
+    close.assert_called_once_with(17)
+
+
+def test_read_file_releases_resources_after_iovec_failure(io_module, monkeypatch):
+    module, native = io_module
+    native.register_fd.return_value = None
+    monkeypatch.setattr(module.os, "open", Mock(return_value=23))
+    close = Mock()
+    monkeypatch.setattr(module.os, "close", close)
+
+    shared_memory = Mock()
+    shared_memory.buf = bytearray(8)
+    monkeypatch.setattr(
+        module.multiprocessing.shared_memory,
+        "SharedMemory",
+        Mock(return_value=shared_memory),
+    )
+    monkeypatch.setattr(module, "make_iovec", Mock(side_effect=RuntimeError("iovec failed")))
+
+    with pytest.raises(RuntimeError, match="iovec failed"):
+        module.read_file("input", hf3fs_mount_point="/3fs", block_size=8)
+
+    native.deregister_fd.assert_called_once_with(23)
+    close.assert_called_once_with(23)
+    shared_memory.close.assert_called_once_with()
+    shared_memory.unlink.assert_called_once_with()
+
+
+def test_read_file_keeps_successful_reads_unchanged(io_module, monkeypatch):
+    module, native = io_module
+    monkeypatch.setattr(module.os, "open", Mock(return_value=29))
+    close = Mock()
+    monkeypatch.setattr(module.os, "close", close)
+
+    shared_memory = Mock()
+    shared_memory.buf = bytearray(b"data-rest")
+    monkeypatch.setattr(
+        module.multiprocessing.shared_memory,
+        "SharedMemory",
+        Mock(return_value=shared_memory),
+    )
+    monkeypatch.setattr(module, "make_iovec", Mock(return_value=shared_memory.buf))
+
+    submission = Mock()
+    submission.wait.return_value = [SimpleNamespace(result=4)]
+    ring = Mock()
+    ring.submit.return_value = submission
+    monkeypatch.setattr(module, "make_ioring", Mock(return_value=ring))
+
+    assert module.read_file("input", hf3fs_mount_point="/3fs", block_size=9) == b"data"
+    ring.prepare.assert_called_once_with(shared_memory.buf[:], True, 29, 0)
+    native.deregister_fd.assert_called_once_with(29)
+    close.assert_called_once_with(29)
+    shared_memory.close.assert_called_once_with()
+    shared_memory.unlink.assert_called_once_with()


### PR DESCRIPTION
Fixes #424

## Summary

Preserve setup failures from `hf3fs_fuse.io.read_file()` and clean up only the
resources that were successfully acquired.

## Root cause

The cleanup block unconditionally referenced `fd`, `ior`, `iov`, and `shm`.
When file opening, native registration, shared-memory creation, iovec creation,
or ioring creation failed, an `UnboundLocalError` could replace the useful
original exception. Failures after shared-memory creation could also skip its
`close()` and `unlink()` calls.

## Fix

- initialize each resource before entering the setup path
- track whether native file-descriptor registration completed
- deregister and close the descriptor only when applicable
- release iovec, ioring, and shared memory only after they exist

Successful read behavior and cleanup order remain unchanged. This also lets an
underlying `make_iovec()` error such as #291 surface correctly; it does not
attempt to solve #291's separate symlink failure.

## Tests

A host-only test with a stubbed native binding covers:

- preserving an `os.open()` failure
- not deregistering a descriptor whose registration failed
- releasing the descriptor after shared-memory creation fails
- releasing the descriptor, registration, and shared memory after iovec setup fails
- releasing the descriptor, registration, and shared memory after ioring setup fails
- unchanged successful reads and cleanup

Validation:

```text
python -m pytest tests/fuse/test_hf3fs_fuse_io.py -q
6 passed in 0.81s

python -m compileall -q hf3fs_fuse tests/fuse/test_hf3fs_fuse_io.py
git diff --check
```

No 3FS mount, RDMA device, external service, or new dependency is required for
the regression test. The full deployment-dependent 3FS suite was not run in
this environment.

