### PR TITLE
docs: remove extra space in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  Fire-Flyer File System
+# Fire-Flyer File System
 
 [![Build](https://github.com/deepseek-ai/3fs/actions/workflows/build.yml/badge.svg)](https://github.com/deepseek-ai/3fs/actions/workflows/build.yml)
 [![License](https://img.shields.io/badge/LICENSE-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
### What

The README heading is `#  Fire-Flyer File System` with a double space after `#`. Other headings in the file use a single space.

### Why

Consistent Markdown heading formatting.

### How I checked

- Grepped README.md headings; this is the only one with a double space.